### PR TITLE
Don't filter out PRs/issues that match the release tag date

### DIFF
--- a/chronicle/release/summarizer/github/gh_issue.go
+++ b/chronicle/release/summarizer/github/gh_issue.go
@@ -45,21 +45,21 @@ issueLoop:
 	return results
 }
 
-func issuesAfter(since time.Time) issueFilter {
+func issuesAtOrAfter(since time.Time) issueFilter {
 	return func(issue ghIssue) bool {
-		keep := issue.ClosedAt.After(since)
+		keep := issue.ClosedAt.After(since) || issue.ClosedAt.Equal(since)
 		if !keep {
-			log.Tracef("issue #%d filtered out: merged before %s", issue.Number, internal.FormatDateTime(since))
+			log.Tracef("issue #%d filtered out: closed before %s (closed %s)", issue.Number, internal.FormatDateTime(since), internal.FormatDateTime(issue.ClosedAt))
 		}
 		return keep
 	}
 }
 
-func issuesBefore(since time.Time) issueFilter {
+func issuesAtOrBefore(since time.Time) issueFilter {
 	return func(issue ghIssue) bool {
-		keep := issue.ClosedAt.Before(since)
+		keep := issue.ClosedAt.Before(since) || issue.ClosedAt.Equal(since)
 		if !keep {
-			log.Tracef("issue #%d filtered out: merged after %s", issue.Number, internal.FormatDateTime(since))
+			log.Tracef("issue #%d filtered out: closed after %s (closed %s)", issue.Number, internal.FormatDateTime(since), internal.FormatDateTime(issue.ClosedAt))
 		}
 		return keep
 	}

--- a/chronicle/release/summarizer/github/gh_issue_test.go
+++ b/chronicle/release/summarizer/github/gh_issue_test.go
@@ -24,6 +24,14 @@ func Test_issuesAfter(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:  "pr is equal to compare date",
+			since: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			issue: ghIssue{
+				ClosedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			},
+			expected: true,
+		},
+		{
 			name:  "pr is after compare date",
 			since: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
 			issue: ghIssue{
@@ -34,7 +42,7 @@ func Test_issuesAfter(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, issuesAfter(test.since)(test.issue))
+			assert.Equal(t, test.expected, issuesAtOrAfter(test.since)(test.issue))
 		})
 	}
 }
@@ -56,6 +64,14 @@ func Test_issuesBefore(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:  "pr is equal to compare date",
+			until: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			issue: ghIssue{
+				ClosedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			},
+			expected: true,
+		},
+		{
 			name:  "pr is before compare date",
 			until: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
 			issue: ghIssue{
@@ -66,7 +82,7 @@ func Test_issuesBefore(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, issuesBefore(test.until)(test.issue))
+			assert.Equal(t, test.expected, issuesAtOrBefore(test.until)(test.issue))
 		})
 	}
 }

--- a/chronicle/release/summarizer/github/gh_pull_request.go
+++ b/chronicle/release/summarizer/github/gh_pull_request.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/anchore/chronicle/internal"
+
 	"github.com/anchore/chronicle/internal/log"
 
 	"github.com/shurcooL/githubv4"
@@ -43,21 +45,21 @@ prLoop:
 	return results
 }
 
-func prsAfter(since time.Time) prFilter {
+func prsAtOrAfter(since time.Time) prFilter {
 	return func(pr ghPullRequest) bool {
-		keep := pr.MergedAt.After(since)
+		keep := pr.MergedAt.After(since) || pr.MergedAt.Equal(since)
 		if !keep {
-			log.Tracef("PR #%d filtered out: merged before %s", pr.Number, since.Format("2006-01-02 15:04"))
+			log.Tracef("PR #%d filtered out: merged before %s (merged %s)", pr.Number, internal.FormatDateTime(since), internal.FormatDateTime(pr.MergedAt))
 		}
 		return keep
 	}
 }
 
-func prsBefore(since time.Time) prFilter {
+func prsAtOrBefore(since time.Time) prFilter {
 	return func(pr ghPullRequest) bool {
-		keep := pr.MergedAt.Before(since)
+		keep := pr.MergedAt.Before(since) || pr.MergedAt.Equal(since)
 		if !keep {
-			log.Tracef("PR #%d filtered out: merged after %s", pr.Number, since.Format("2006-01-02 15:04"))
+			log.Tracef("PR #%d filtered out: merged after %s (merged %s)", pr.Number, internal.FormatDateTime(since), internal.FormatDateTime(pr.MergedAt))
 		}
 		return keep
 	}

--- a/chronicle/release/summarizer/github/gh_pull_request_test.go
+++ b/chronicle/release/summarizer/github/gh_pull_request_test.go
@@ -24,6 +24,14 @@ func Test_prsAfter(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:  "pr is equal to compare date",
+			since: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
+			pr: ghPullRequest{
+				MergedAt: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
+			},
+			expected: true,
+		},
+		{
 			name:  "pr is after compare date",
 			since: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
 			pr: ghPullRequest{
@@ -34,7 +42,7 @@ func Test_prsAfter(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, prsAfter(test.since)(test.pr))
+			assert.Equal(t, test.expected, prsAtOrAfter(test.since)(test.pr))
 		})
 	}
 }
@@ -56,6 +64,14 @@ func Test_prsBefore(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:  "pr is equal to compare date",
+			until: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			pr: ghPullRequest{
+				MergedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			},
+			expected: true,
+		},
+		{
 			name:  "pr is before compare date",
 			until: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
 			pr: ghPullRequest{
@@ -66,7 +82,7 @@ func Test_prsBefore(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, prsBefore(test.until)(test.pr))
+			assert.Equal(t, test.expected, prsAtOrBefore(test.until)(test.pr))
 		})
 	}
 }

--- a/chronicle/release/summarizer/github/summarizer.go
+++ b/chronicle/release/summarizer/github/summarizer.go
@@ -120,7 +120,7 @@ func (s *Summarizer) changesFromPRs(sinceRef, untilRef string) ([]change.Change,
 	}
 
 	filters := []prFilter{
-		prsAfter(sinceTag.Timestamp),
+		prsAtOrAfter(sinceTag.Timestamp.UTC()),
 		prsWithLabel(s.config.ChangeTypesByLabel.Names()...),
 		prsWithoutLabel(s.config.ExcludeLabels...),
 		// Merged PRs linked to closed issues should be hidden so that the closed pr summary takes precedence
@@ -136,7 +136,7 @@ func (s *Summarizer) changesFromPRs(sinceRef, untilRef string) ([]change.Change,
 			return nil, err
 		}
 
-		filters = append(filters, prsBefore(untilTag.Timestamp))
+		filters = append(filters, prsAtOrBefore(untilTag.Timestamp.UTC()))
 	}
 
 	filteredPRs := filterPRs(allMergedPRs, filters...)
@@ -183,7 +183,7 @@ func (s *Summarizer) changesFromIssues(sinceRef, untilRef string) ([]change.Chan
 	}
 
 	filters := []issueFilter{
-		issuesAfter(sinceTag.Timestamp),
+		issuesAtOrAfter(sinceTag.Timestamp),
 		issuesWithLabel(s.config.ChangeTypesByLabel.Names()...),
 		issuesWithoutLabel(s.config.ExcludeLabels...),
 	}
@@ -194,7 +194,7 @@ func (s *Summarizer) changesFromIssues(sinceRef, untilRef string) ([]change.Chan
 			return nil, err
 		}
 
-		filters = append(filters, issuesBefore(untilTag.Timestamp))
+		filters = append(filters, issuesAtOrBefore(untilTag.Timestamp))
 	}
 
 	filteredIssues := filterIssues(allClosedIssues, filters...)

--- a/internal/time_helper.go
+++ b/internal/time_helper.go
@@ -3,5 +3,5 @@ package internal
 import "time"
 
 func FormatDateTime(t time.Time) string {
-	return t.Format("YYYY-MM-DD 15:04")
+	return t.UTC().Format("2006-01-02 15:04 MST")
 }


### PR DESCRIPTION
There is an edge case where if an issue or PR close timestamp matches the same timestamp as the release the changelog is being generated for, then the PR/issue in question is filtered out:
```
[0000] DEBUG github owner="wagoodman" repo="chronicle-test" path="../chronicle-test"
[0000]  INFO since tag="v0.0.0" date="2022-03-23 20:24 UTC"
[0000]  INFO until tag="v0.1.0" commit="5d95ff3aba8b6619b59f85f24332bc3ab5b0ae11"
[0000] DEBUG total merged PRs discovered: 2
[0000] TRACE PR #2 filtered out: merged after 2022-03-23 20:19 UTC (merged 2022-03-23 20:19 UTC)
[0000] DEBUG PRs contributing to changelog: 1
[0000] DEBUG total closed issues discovered: 0
[0000] DEBUG issues contributing to changelog: 0
[0000]  INFO discovered changes: 1
[0000] DEBUG   └── added-feature: 1
```

The correct behavior (which this PR fixes) is to keep the edge PR/issue included in the list of changes:
```
[0000] DEBUG github owner="wagoodman" repo="chronicle-test" path="../chronicle-test"
[0000]  INFO since tag="v0.0.0" date="2022-03-23 20:24 UTC"
[0000]  INFO until tag="v0.1.0" commit="5d95ff3aba8b6619b59f85f24332bc3ab5b0ae11"
[0000] DEBUG total merged PRs discovered: 2
[0000] DEBUG PRs contributing to changelog: 2
[0000] DEBUG total closed issues discovered: 0
[0000] DEBUG issues contributing to changelog: 0
[0000]  INFO discovered changes: 2
[0000] DEBUG   └── added-feature: 2
```