### PR TITLE
Add next-version command

### DIFF
--- a/.chronicle.yaml
+++ b/.chronicle.yaml
@@ -1,2 +1,4 @@
 github:
   include-prs: true
+log:
+  level: trace

--- a/chronicle/release/change/semver.go
+++ b/chronicle/release/change/semver.go
@@ -1,0 +1,51 @@
+package change
+
+import "strings"
+
+type SemVerKind int
+
+const (
+	SemVerUnknown SemVerKind = iota
+	SemVerPatch
+	SemVerMinor
+	SemVerMajor
+)
+
+var SemVerFields = []SemVerKind{
+	SemVerMajor,
+	SemVerMinor,
+	SemVerPatch,
+}
+
+func ParseSemVerKind(semver string) SemVerKind {
+	for _, f := range SemVerFields {
+		if f.String() == strings.ToLower(semver) {
+			return f
+		}
+	}
+	return SemVerUnknown
+}
+
+func (f SemVerKind) String() string {
+	switch f {
+	case SemVerMajor:
+		return "major"
+	case SemVerMinor:
+		return "minor"
+	case SemVerPatch:
+		return "patch"
+	}
+	return ""
+}
+
+func Significance(changes []Change) SemVerKind {
+	var current = SemVerUnknown
+	for _, c := range changes {
+		for _, t := range c.ChangeTypes {
+			if t.Kind > current {
+				current = t.Kind
+			}
+		}
+	}
+	return current
+}

--- a/chronicle/release/change/type.go
+++ b/chronicle/release/change/type.go
@@ -1,11 +1,21 @@
 package change
 
-type Type string
+type Type struct {
+	Name string
+	Kind SemVerKind
+}
+
+func NewType(name string, kind SemVerKind) Type {
+	return Type{
+		Name: name,
+		Kind: kind,
+	}
+}
 
 func ContainsAny(query, against []Type) bool {
 	for _, qt := range query {
 		for _, at := range against {
-			if qt == at {
+			if qt.Name == at.Name {
 				return true
 			}
 		}

--- a/chronicle/release/find_next_version.go
+++ b/chronicle/release/find_next_version.go
@@ -1,0 +1,57 @@
+package release
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/anchore/chronicle/chronicle/release/change"
+	"github.com/coreos/go-semver/semver"
+)
+
+func FindNextVersion(currentVersion string, changes change.Changes, enforceV0 bool) (string, error) {
+	var breaking, feature, patch bool
+	for _, c := range changes {
+		for _, chTy := range c.ChangeTypes {
+			switch chTy.Kind {
+			case change.SemVerMajor:
+				if enforceV0 {
+					feature = true
+				} else {
+					breaking = true
+				}
+			case change.SemVerMinor:
+				feature = true
+			case change.SemVerPatch:
+				patch = true
+			}
+		}
+	}
+
+	v, err := semver.NewVersion(strings.TrimLeft(currentVersion, "v"))
+	if err != nil {
+		return "", fmt.Errorf("invalid current version given: %q: %w", currentVersion, err)
+	}
+	original := *v
+
+	if patch {
+		v.BumpPatch()
+	}
+
+	if feature {
+		v.BumpMinor()
+	}
+
+	if breaking {
+		v.BumpMajor()
+	}
+
+	if v.String() == original.String() {
+		return "", fmt.Errorf("no changes found that affect the version (changes=%d)", len(changes))
+	}
+
+	prefix := ""
+	if strings.HasPrefix(currentVersion, "v") {
+		prefix = "v"
+	}
+	return prefix + v.String(), nil
+}

--- a/chronicle/release/find_next_version_test.go
+++ b/chronicle/release/find_next_version_test.go
@@ -1,0 +1,129 @@
+package release
+
+import (
+	"github.com/anchore/chronicle/chronicle/release/change"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestFindNextVersion(t *testing.T) {
+	majorChange := change.Type{
+		Kind: change.SemVerMajor,
+	}
+
+	minorChange := change.Type{
+		Kind: change.SemVerMinor,
+	}
+
+	patchChange := change.Type{
+		Kind: change.SemVerPatch,
+	}
+
+	tests := []struct {
+		name      string
+		release   string
+		changes   change.Changes
+		enforceV0 bool
+		want      string
+		wantErr   require.ErrorAssertionFunc
+	}{
+		{
+			name:    "bump major version",
+			release: "v0.1.5",
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{majorChange, minorChange, patchChange},
+				},
+			},
+			want: "v1.0.0",
+		},
+		{
+			name:      "bump major version -- enforce v0",
+			release:   "v0.1.5",
+			enforceV0: true,
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{majorChange, minorChange, patchChange},
+				},
+			},
+			want: "v0.2.0",
+		},
+		{
+			name:      "bump major version -- enforce v0 -- keep major",
+			release:   "v6.1.5",
+			enforceV0: true,
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{majorChange, minorChange, patchChange},
+				},
+			},
+			want: "v6.2.0",
+		},
+		{
+			name:    "bump major version -- ignore dups",
+			release: "v0.1.5",
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{majorChange, majorChange, majorChange, majorChange, majorChange, majorChange},
+				},
+			},
+			want: "v1.0.0",
+		},
+		{
+			name:    "bump minor version",
+			release: "v0.1.5",
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{minorChange, patchChange},
+				},
+			},
+			want: "v0.2.0",
+		},
+		{
+			name:    "bump patch version",
+			release: "v0.1.5",
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{patchChange},
+				},
+			},
+			want: "v0.1.6",
+		},
+		{
+			name:    "honor no prefix",
+			release: "0.1.5",
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{patchChange},
+				},
+			},
+			want: "0.1.6",
+		},
+		{
+			name:    "honor no prefix",
+			release: "0.1.5",
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{patchChange},
+				},
+			},
+			want: "0.1.6",
+		},
+		{
+			name:    "error on bad version",
+			release: "a10",
+			wantErr: require.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
+			}
+			got, err := FindNextVersion(tt.release, tt.changes, tt.enforceV0)
+			tt.wantErr(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/chronicle/release/format/markdown/presenter_test.go
+++ b/chronicle/release/format/markdown/presenter_test.go
@@ -31,19 +31,19 @@ func TestMarkdownPresenter_Present(t *testing.T) {
 				Description: release.Description{
 					SupportedChanges: []change.TypeTitle{
 						{
-							ChangeType: "bug",
+							ChangeType: change.NewType("bug", change.SemVerPatch),
 							Title:      "Bug Fixes",
 						},
 						{
-							ChangeType: "added",
+							ChangeType: change.NewType("added", change.SemVerMinor),
 							Title:      "Added Features",
 						},
 						{
-							ChangeType: "breaking",
+							ChangeType: change.NewType("breaking", change.SemVerMajor),
 							Title:      "Breaking Changes",
 						},
 						{
-							ChangeType: "removed",
+							ChangeType: change.NewType("removed", change.SemVerMajor),
 							Title:      "Removed Features",
 						},
 					},
@@ -55,7 +55,7 @@ func TestMarkdownPresenter_Present(t *testing.T) {
 					VCSChangesURL:   "https://github.com/anchore/syft/compare/v0.19.0...v0.19.1",
 					Changes: []change.Change{
 						{
-							ChangeTypes: []change.Type{"bug"},
+							ChangeTypes: []change.Type{change.NewType("bug", change.SemVerPatch)},
 							Text:        "Redirect cursor hide/show to stderr",
 							References: []change.Reference{
 								{
@@ -65,15 +65,15 @@ func TestMarkdownPresenter_Present(t *testing.T) {
 							},
 						},
 						{
-							ChangeTypes: []change.Type{"added"},
+							ChangeTypes: []change.Type{change.NewType("added", change.SemVerMinor)},
 							Text:        "added feature",
 						},
 						{
-							ChangeTypes: []change.Type{"added"},
+							ChangeTypes: []change.Type{change.NewType("added", change.SemVerMinor)},
 							Text:        "another added feature",
 						},
 						{
-							ChangeTypes: []change.Type{"breaking"},
+							ChangeTypes: []change.Type{change.NewType("breaking", change.SemVerMajor)},
 							Text:        "breaking change",
 						},
 					},

--- a/chronicle/release/release.go
+++ b/chronicle/release/release.go
@@ -1,6 +1,8 @@
 package release
 
-import "time"
+import (
+	"time"
+)
 
 type Release struct {
 	Version string

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -92,17 +92,17 @@ func bindCreateConfigOptions(flags *pflag.FlagSet) error {
 func runCreate(cmd *cobra.Command, args []string) error {
 	worker := selectWorker(appConfig.CliOptions.RepoPath)
 
-	description, err := worker()
+	_, description, err := worker()
 	if err != nil {
 		return err
 	}
 
-	format := format.FromString(appConfig.Output)
-	if format == nil {
+	f := format.FromString(appConfig.Output)
+	if f == nil {
 		return fmt.Errorf("unable to parse output format: %q", appConfig.Output)
 	}
 
-	presenterTask, err := selectPresenter(*format)
+	presenterTask, err := selectPresenter(*f)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	return p.Present(os.Stdout)
 }
 
-func selectWorker(repo string) func() (*release.Description, error) {
+func selectWorker(repo string) func() (*release.Release, *release.Description, error) {
 	// TODO: we only support github, but this is the spot to add support for other providers such as GitLab or Bitbucket or other VCSs altogether, such as subversion.
 	return createChangelogFromGithub
 }
@@ -124,26 +124,26 @@ func logChanges(changes change.Changes) {
 	log.Infof("discovered changes: %d", len(changes))
 
 	set := strset.New()
-	count := make(map[change.Type]int)
+	count := make(map[string]int)
 	for _, c := range changes {
 		for _, ty := range c.ChangeTypes {
-			_, exists := count[ty]
+			_, exists := count[ty.Name]
 			if !exists {
-				count[ty] = 0
+				count[ty.Name] = 0
 			}
-			count[ty]++
-			set.Add(string(ty))
+			count[ty.Name]++
+			set.Add(ty.Name)
 		}
 	}
 
-	types := set.List()
-	sort.Strings(types)
+	typeNames := set.List()
+	sort.Strings(typeNames)
 
-	for idx, ty := range types {
+	for idx, tyName := range typeNames {
 		var branch = "├──"
-		if idx == len(types)-1 {
+		if idx == len(typeNames)-1 {
 			branch = "└──"
 		}
-		log.Debugf("  %s %s: %d", branch, ty, count[change.Type(ty)])
+		log.Debugf("  %s %s: %d", branch, tyName, count[tyName])
 	}
 }

--- a/cmd/next_version.go
+++ b/cmd/next_version.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/anchore/chronicle/chronicle/release/change"
+	"github.com/anchore/chronicle/internal/git"
+	"github.com/anchore/chronicle/internal/log"
+	"github.com/coreos/go-semver/semver"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+var nextVersionCmd = &cobra.Command{
+	Use:   "next-version [PATH]",
+	Short: "Guess the next version based on the changelog diff from the last release",
+	Args:  cobra.MaximumNArgs(1),
+	RunE:  runNextVersion,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		var repo = "./"
+		if len(args) == 1 {
+			if !git.IsRepository(args[0]) {
+				return fmt.Errorf("given path is not a git repository: %s", args[0])
+			}
+			repo = args[0]
+		} else {
+			log.Infof("no repository path given, assuming %q", repo)
+		}
+		appConfig.CliOptions.RepoPath = repo
+		return nil
+	},
+}
+
+func init() {
+	setNextVersionFlags(nextVersionCmd.Flags())
+	if err := bindNextVersionConfigOptions(nextVersionCmd.Flags()); err != nil {
+		panic(err)
+	}
+
+	rootCmd.AddCommand(nextVersionCmd)
+}
+
+func setNextVersionFlags(flags *pflag.FlagSet) {
+	flags.BoolP(
+		"enforce-v0", "e", false,
+		"major changes bump the minor version field for versions < 1.0",
+	)
+}
+
+func bindNextVersionConfigOptions(flags *pflag.FlagSet) error {
+	if err := viper.BindPFlag("enforce-v0", flags.Lookup("enforce-v0")); err != nil {
+		return err
+	}
+	return nil
+}
+
+func runNextVersion(cmd *cobra.Command, args []string) error {
+	worker := selectWorker(appConfig.CliOptions.RepoPath)
+
+	release, description, err := worker()
+	if err != nil {
+		return err
+	}
+
+	var breaking, feature, patch bool
+	for _, c := range description.Changes {
+		for _, chTy := range c.ChangeTypes {
+			switch chTy.Kind {
+			case change.SemVerMajor:
+				if appConfig.EnforceV0 {
+					feature = true
+				} else {
+					breaking = true
+				}
+			case change.SemVerMinor:
+				feature = true
+			case change.SemVerPatch:
+				patch = true
+			}
+		}
+	}
+
+	v := semver.New(strings.TrimLeft(release.Version, "v"))
+	original := *v
+
+	if patch {
+		v.BumpPatch()
+	}
+
+	if feature {
+		v.BumpMinor()
+	}
+
+	if breaking {
+		v.BumpMajor()
+	}
+
+	if v.String() == original.String() {
+		return fmt.Errorf("no changes found that affect the version (changes=%d)", len(description.Changes))
+	}
+
+	prefix := ""
+	if strings.HasPrefix("v", release.Version) {
+		prefix = "v"
+	}
+
+	_, err = os.Stdout.Write([]byte(prefix + v.String()))
+
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/adrg/xdg v0.3.3
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4
+	github.com/coreos/go-semver v0.3.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gookit/color v1.4.2
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -26,16 +26,17 @@ type parser interface {
 }
 
 type Application struct {
-	ConfigPath string           `yaml:",omitempty" json:"configPath"`               // the location where the application config was read from (either from -c or discovered while loading)
-	Output     string           `yaml:"output" json:"output" mapstructure:"output"` // -o, the Presenter hint string to use for report formatting
-	Quiet      bool             `yaml:"quiet" json:"quiet" mapstructure:"quiet"`    // -q, indicates to not show any status output to stderr (ETUI or logging UI)
-	Log        logging          `yaml:"log" json:"log" mapstructure:"log"`          // all logging-related options
-	CliOptions CliOnlyOptions   `yaml:"-" json:"-"`                                 // all options only available through the CLI (not via env vars or config)
-	SinceTag   string           `yaml:"since-tag" json:"since-tag" mapstructure:"since-tag"`
-	UntilTag   string           `yaml:"until-tag" json:"until-tag" mapstructure:"until-tag"`
-	EnforceV0  bool             `yaml:"enforce-v0" json:"enforce-v0" mapstructure:"enforce-v0"`
-	Title      string           `yaml:"title" json:"title" mapstructure:"title"`
-	Github     githubSummarizer `yaml:"github" json:"github" mapstructure:"github"`
+	ConfigPath           string           `yaml:",omitempty" json:"configPath"`                                                               // the location where the application config was read from (either from -c or discovered while loading)
+	Output               string           `yaml:"output" json:"output" mapstructure:"output"`                                                 // -o, the Presenter hint string to use for report formatting
+	Quiet                bool             `yaml:"quiet" json:"quiet" mapstructure:"quiet"`                                                    // -q, indicates to not show any status output to stderr (ETUI or logging UI)
+	Log                  logging          `yaml:"log" json:"log" mapstructure:"log"`                                                          // all logging-related options
+	CliOptions           CliOnlyOptions   `yaml:"-" json:"-"`                                                                                 // all options only available through the CLI (not via env vars or config)
+	SpeculateNextVersion bool             `yaml:"speculate-next-version" json:"speculate-next-version" mapstructure:"speculate-next-version"` // -n, guess the next version based on issues and PRs
+	SinceTag             string           `yaml:"since-tag" json:"since-tag" mapstructure:"since-tag"`
+	UntilTag             string           `yaml:"until-tag" json:"until-tag" mapstructure:"until-tag"`
+	EnforceV0            bool             `yaml:"enforce-v0" json:"enforce-v0" mapstructure:"enforce-v0"`
+	Title                string           `yaml:"title" json:"title" mapstructure:"title"`
+	Github               githubSummarizer `yaml:"github" json:"github" mapstructure:"github"`
 }
 
 func newApplicationConfig(v *viper.Viper, cliOpts CliOnlyOptions) *Application {
@@ -85,6 +86,10 @@ func (cfg Application) loadDefaultValues(v *viper.Viper) {
 
 // build inflates simple config values into native objects (or other complex objects) after the config is fully read in.
 func (cfg *Application) parseConfigValues() error {
+	if cfg.SpeculateNextVersion && cfg.UntilTag != "" {
+		return errors.New("cannot specify both --speculate-next-version and --until-tag")
+	}
+
 	if cfg.Quiet {
 		// TODO: this is bad: quiet option trumps all other logging options
 		// we should be able to quiet the console logging and leave file logging alone...

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -33,6 +33,7 @@ type Application struct {
 	CliOptions CliOnlyOptions   `yaml:"-" json:"-"`                                 // all options only available through the CLI (not via env vars or config)
 	SinceTag   string           `yaml:"since-tag" json:"since-tag" mapstructure:"since-tag"`
 	UntilTag   string           `yaml:"until-tag" json:"until-tag" mapstructure:"until-tag"`
+	EnforceV0  bool             `yaml:"enforce-v0" json:"enforce-v0" mapstructure:"enforce-v0"`
 	Title      string           `yaml:"title" json:"title" mapstructure:"title"`
 	Github     githubSummarizer `yaml:"github" json:"github" mapstructure:"github"`
 }


### PR DESCRIPTION
Adds the ability to speculate what the next release version might be from the set of changes discovered. This is expressed as two new features:

1. Adding a `next-version` command
```
# last github release: v0.1.0 
# state: one bug and one feature added since v0.1.0

$ chronicle next-version .
v0.2.0
```

2. Allow the `create` command to speculate the next version instead of report "unreleased"

```
# same release / repo state from (1)

$ chronicle > /tmp/changelog-1.txt
$ chronicle -n > /tmp/changelog-2.txt
```

```diff
# diff /tmp/changelog-1.txt /tmp/changelog-2.txt
3c3
< ## [(Unreleased)](https://github.com/wagoodman/chronicle-test/tree/4e685278ed9a268806c4d7fe534d2d58d6ca0d70) (2022-03-24)
---
> ## [v0.2.0](https://github.com/wagoodman/chronicle-test/tree/v0.2.0) (2022-03-24)
5c5
< [Full Changelog](https://github.com/wagoodman/chronicle-test/compare/v0.1.0...4e685278ed9a268806c4d7fe534d2d58d6ca0d70)
---
> [Full Changelog](https://github.com/wagoodman/chronicle-test/compare/v0.1.0...v0.2.0)

```