### PR TITLE
Fix edge case for "PRs since" summarizer filter

### DIFF
--- a/chronicle/release/summarizer/github/gh_issue.go
+++ b/chronicle/release/summarizer/github/gh_issue.go
@@ -45,11 +45,12 @@ issueLoop:
 	return results
 }
 
+// nolint:deadcode,unused
 func issuesAtOrAfter(since time.Time) issueFilter {
 	return func(issue ghIssue) bool {
 		keep := issue.ClosedAt.After(since) || issue.ClosedAt.Equal(since)
 		if !keep {
-			log.Tracef("issue #%d filtered out: closed before %s (closed %s)", issue.Number, internal.FormatDateTime(since), internal.FormatDateTime(issue.ClosedAt))
+			log.Tracef("issue #%d filtered out: closed at or before %s (closed %s)", issue.Number, internal.FormatDateTime(since), internal.FormatDateTime(issue.ClosedAt))
 		}
 		return keep
 	}
@@ -58,6 +59,27 @@ func issuesAtOrAfter(since time.Time) issueFilter {
 func issuesAtOrBefore(since time.Time) issueFilter {
 	return func(issue ghIssue) bool {
 		keep := issue.ClosedAt.Before(since) || issue.ClosedAt.Equal(since)
+		if !keep {
+			log.Tracef("issue #%d filtered out: closed at or after %s (closed %s)", issue.Number, internal.FormatDateTime(since), internal.FormatDateTime(issue.ClosedAt))
+		}
+		return keep
+	}
+}
+
+func issuesAfter(since time.Time) issueFilter {
+	return func(issue ghIssue) bool {
+		keep := issue.ClosedAt.After(since)
+		if !keep {
+			log.Tracef("issue #%d filtered out: closed before %s (closed %s)", issue.Number, internal.FormatDateTime(since), internal.FormatDateTime(issue.ClosedAt))
+		}
+		return keep
+	}
+}
+
+// nolint:deadcode,unused
+func issuesBefore(since time.Time) issueFilter {
+	return func(issue ghIssue) bool {
+		keep := issue.ClosedAt.Before(since)
 		if !keep {
 			log.Tracef("issue #%d filtered out: closed after %s (closed %s)", issue.Number, internal.FormatDateTime(since), internal.FormatDateTime(issue.ClosedAt))
 		}

--- a/chronicle/release/summarizer/github/gh_issue_test.go
+++ b/chronicle/release/summarizer/github/gh_issue_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_issuesAfter(t *testing.T) {
+func Test_issuesAtOrAfter(t *testing.T) {
 
 	tests := []struct {
 		name     string
@@ -16,7 +16,7 @@ func Test_issuesAfter(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:  "pr is before compare date",
+			name:  "issue is before compare date",
 			since: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
 			issue: ghIssue{
 				ClosedAt: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
@@ -24,7 +24,7 @@ func Test_issuesAfter(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:  "pr is equal to compare date",
+			name:  "issue is equal to compare date",
 			since: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
 			issue: ghIssue{
 				ClosedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
@@ -32,7 +32,7 @@ func Test_issuesAfter(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:  "pr is after compare date",
+			name:  "issue is after compare date",
 			since: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
 			issue: ghIssue{
 				ClosedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
@@ -47,7 +47,47 @@ func Test_issuesAfter(t *testing.T) {
 	}
 }
 
-func Test_issuesBefore(t *testing.T) {
+func Test_issuesAfter(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		issue    ghIssue
+		since    time.Time
+		expected bool
+	}{
+		{
+			name:  "issue is before compare date",
+			since: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			issue: ghIssue{
+				ClosedAt: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
+			},
+			expected: false,
+		},
+		{
+			name:  "issue is equal to compare date",
+			since: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			issue: ghIssue{
+				ClosedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			},
+			expected: false,
+		},
+		{
+			name:  "issue is after compare date",
+			since: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
+			issue: ghIssue{
+				ClosedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			},
+			expected: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, issuesAfter(test.since)(test.issue))
+		})
+	}
+}
+
+func Test_issuesAtOrBefore(t *testing.T) {
 
 	tests := []struct {
 		name     string
@@ -56,7 +96,7 @@ func Test_issuesBefore(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:  "pr is after compare date",
+			name:  "issue is after compare date",
 			until: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
 			issue: ghIssue{
 				ClosedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
@@ -64,7 +104,7 @@ func Test_issuesBefore(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:  "pr is equal to compare date",
+			name:  "issue is equal to compare date",
 			until: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
 			issue: ghIssue{
 				ClosedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
@@ -72,7 +112,7 @@ func Test_issuesBefore(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:  "pr is before compare date",
+			name:  "issue is before compare date",
 			until: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
 			issue: ghIssue{
 				ClosedAt: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
@@ -83,6 +123,46 @@ func Test_issuesBefore(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.expected, issuesAtOrBefore(test.until)(test.issue))
+		})
+	}
+}
+
+func Test_issuesBefore(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		issue    ghIssue
+		until    time.Time
+		expected bool
+	}{
+		{
+			name:  "issue is after compare date",
+			until: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
+			issue: ghIssue{
+				ClosedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			},
+			expected: false,
+		},
+		{
+			name:  "issue is equal to compare date",
+			until: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			issue: ghIssue{
+				ClosedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			},
+			expected: false,
+		},
+		{
+			name:  "issue is before compare date",
+			until: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			issue: ghIssue{
+				ClosedAt: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
+			},
+			expected: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, issuesBefore(test.until)(test.issue))
 		})
 	}
 }

--- a/chronicle/release/summarizer/github/gh_pull_request.go
+++ b/chronicle/release/summarizer/github/gh_pull_request.go
@@ -45,11 +45,12 @@ prLoop:
 	return results
 }
 
+// nolint:deadcode,unused
 func prsAtOrAfter(since time.Time) prFilter {
 	return func(pr ghPullRequest) bool {
 		keep := pr.MergedAt.After(since) || pr.MergedAt.Equal(since)
 		if !keep {
-			log.Tracef("PR #%d filtered out: merged before %s (merged %s)", pr.Number, internal.FormatDateTime(since), internal.FormatDateTime(pr.MergedAt))
+			log.Tracef("PR #%d filtered out: merged at or before %s (merged %s)", pr.Number, internal.FormatDateTime(since), internal.FormatDateTime(pr.MergedAt))
 		}
 		return keep
 	}
@@ -59,13 +60,34 @@ func prsAtOrBefore(since time.Time) prFilter {
 	return func(pr ghPullRequest) bool {
 		keep := pr.MergedAt.Before(since) || pr.MergedAt.Equal(since)
 		if !keep {
+			log.Tracef("PR #%d filtered out: merged at or after %s (merged %s)", pr.Number, internal.FormatDateTime(since), internal.FormatDateTime(pr.MergedAt))
+		}
+		return keep
+	}
+}
+
+func prsAfter(since time.Time) prFilter {
+	return func(pr ghPullRequest) bool {
+		keep := pr.MergedAt.After(since)
+		if !keep {
+			log.Tracef("PR #%d filtered out: merged before %s (merged %s)", pr.Number, internal.FormatDateTime(since), internal.FormatDateTime(pr.MergedAt))
+		}
+		return keep
+	}
+}
+
+// nolint:deadcode,unused
+func prsBefore(since time.Time) prFilter {
+	return func(pr ghPullRequest) bool {
+		keep := pr.MergedAt.Before(since)
+		if !keep {
 			log.Tracef("PR #%d filtered out: merged after %s (merged %s)", pr.Number, internal.FormatDateTime(since), internal.FormatDateTime(pr.MergedAt))
 		}
 		return keep
 	}
 }
 
-func prsWithClosedLinkedIssue() prFilter {
+func prsWithoutClosedLinkedIssue() prFilter {
 	return func(pr ghPullRequest) bool {
 		for _, i := range pr.LinkedIssues {
 			if i.Closed {
@@ -77,7 +99,7 @@ func prsWithClosedLinkedIssue() prFilter {
 	}
 }
 
-func prsWithOpenLinkedIssue() prFilter {
+func prsWithoutOpenLinkedIssue() prFilter {
 	return func(pr ghPullRequest) bool {
 		for _, i := range pr.LinkedIssues {
 			if !i.Closed {

--- a/chronicle/release/summarizer/github/gh_pull_request_test.go
+++ b/chronicle/release/summarizer/github/gh_pull_request_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_prsAfter(t *testing.T) {
+func Test_prsAtOrAfter(t *testing.T) {
 
 	tests := []struct {
-		name     string
-		pr       ghPullRequest
-		since    time.Time
-		expected bool
+		name  string
+		pr    ghPullRequest
+		since time.Time
+		keep  bool
 	}{
 		{
 			name:  "pr is before compare date",
@@ -21,7 +21,7 @@ func Test_prsAfter(t *testing.T) {
 			pr: ghPullRequest{
 				MergedAt: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
 			},
-			expected: false,
+			keep: false,
 		},
 		{
 			name:  "pr is equal to compare date",
@@ -29,7 +29,7 @@ func Test_prsAfter(t *testing.T) {
 			pr: ghPullRequest{
 				MergedAt: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
 			},
-			expected: true,
+			keep: true,
 		},
 		{
 			name:  "pr is after compare date",
@@ -37,23 +37,63 @@ func Test_prsAfter(t *testing.T) {
 			pr: ghPullRequest{
 				MergedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
 			},
-			expected: true,
+			keep: true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, prsAtOrAfter(test.since)(test.pr))
+			assert.Equal(t, test.keep, prsAtOrAfter(test.since)(test.pr))
 		})
 	}
 }
 
-func Test_prsBefore(t *testing.T) {
+func Test_prsAfter(t *testing.T) {
 
 	tests := []struct {
-		name     string
-		pr       ghPullRequest
-		until    time.Time
-		expected bool
+		name  string
+		pr    ghPullRequest
+		since time.Time
+		keep  bool
+	}{
+		{
+			name:  "pr is before compare date",
+			since: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			pr: ghPullRequest{
+				MergedAt: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
+			},
+			keep: false,
+		},
+		{
+			name:  "pr is equal to compare date",
+			since: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
+			pr: ghPullRequest{
+				MergedAt: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
+			},
+			keep: false,
+		},
+		{
+			name:  "pr is after compare date",
+			since: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
+			pr: ghPullRequest{
+				MergedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			},
+			keep: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.keep, prsAfter(test.since)(test.pr))
+		})
+	}
+}
+
+func Test_prsAtOrBefore(t *testing.T) {
+
+	tests := []struct {
+		name  string
+		pr    ghPullRequest
+		until time.Time
+		keep  bool
 	}{
 		{
 			name:  "pr is after compare date",
@@ -61,7 +101,7 @@ func Test_prsBefore(t *testing.T) {
 			pr: ghPullRequest{
 				MergedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
 			},
-			expected: false,
+			keep: false,
 		},
 		{
 			name:  "pr is equal to compare date",
@@ -69,7 +109,7 @@ func Test_prsBefore(t *testing.T) {
 			pr: ghPullRequest{
 				MergedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
 			},
-			expected: true,
+			keep: true,
 		},
 		{
 			name:  "pr is before compare date",
@@ -77,12 +117,52 @@ func Test_prsBefore(t *testing.T) {
 			pr: ghPullRequest{
 				MergedAt: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
 			},
-			expected: true,
+			keep: true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, prsAtOrBefore(test.until)(test.pr))
+			assert.Equal(t, test.keep, prsAtOrBefore(test.until)(test.pr))
+		})
+	}
+}
+
+func Test_prsBefore(t *testing.T) {
+
+	tests := []struct {
+		name  string
+		pr    ghPullRequest
+		until time.Time
+		keep  bool
+	}{
+		{
+			name:  "pr is after compare date",
+			until: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
+			pr: ghPullRequest{
+				MergedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			},
+			keep: false,
+		},
+		{
+			name:  "pr is equal to compare date",
+			until: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			pr: ghPullRequest{
+				MergedAt: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			},
+			keep: false,
+		},
+		{
+			name:  "pr is before compare date",
+			until: time.Date(2021, time.September, 18, 19, 34, 0, 0, time.UTC),
+			pr: ghPullRequest{
+				MergedAt: time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC),
+			},
+			keep: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.keep, prsBefore(test.until)(test.pr))
 		})
 	}
 }
@@ -90,10 +170,10 @@ func Test_prsBefore(t *testing.T) {
 func Test_prsWithLabel(t *testing.T) {
 
 	tests := []struct {
-		name     string
-		pr       ghPullRequest
-		labels   []string
-		expected bool
+		name   string
+		pr     ghPullRequest
+		labels []string
+		keep   bool
 	}{
 		{
 			name: "matches on label",
@@ -103,7 +183,7 @@ func Test_prsWithLabel(t *testing.T) {
 			pr: ghPullRequest{
 				Labels: []string{"something-else", "positive"},
 			},
-			expected: true,
+			keep: true,
 		},
 		{
 			name: "does not match on label",
@@ -113,12 +193,12 @@ func Test_prsWithLabel(t *testing.T) {
 			pr: ghPullRequest{
 				Labels: []string{"something-else", "negative"},
 			},
-			expected: false,
+			keep: false,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, prsWithLabel(test.labels...)(test.pr))
+			assert.Equal(t, test.keep, prsWithLabel(test.labels...)(test.pr))
 		})
 	}
 }
@@ -126,10 +206,10 @@ func Test_prsWithLabel(t *testing.T) {
 func Test_prsWithoutLabel(t *testing.T) {
 
 	tests := []struct {
-		name     string
-		pr       ghPullRequest
-		labels   []string
-		expected bool
+		name   string
+		pr     ghPullRequest
+		labels []string
+		keep   bool
 	}{
 		{
 			name: "matches on label",
@@ -139,7 +219,7 @@ func Test_prsWithoutLabel(t *testing.T) {
 			pr: ghPullRequest{
 				Labels: []string{"something-else", "positive"},
 			},
-			expected: false,
+			keep: false,
 		},
 		{
 			name: "does not match on label",
@@ -149,22 +229,22 @@ func Test_prsWithoutLabel(t *testing.T) {
 			pr: ghPullRequest{
 				Labels: []string{"something-else", "negative"},
 			},
-			expected: true,
+			keep: true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, prsWithoutLabel(test.labels...)(test.pr))
+			assert.Equal(t, test.keep, prsWithoutLabel(test.labels...)(test.pr))
 		})
 	}
 }
 
-func Test_prsWithClosedLinkedIssue(t *testing.T) {
+func Test_prsWithoutClosedLinkedIssue(t *testing.T) {
 
 	tests := []struct {
-		name     string
-		pr       ghPullRequest
-		expected bool
+		name string
+		pr   ghPullRequest
+		keep bool
 	}{
 		{
 			name: "has closed linked issue",
@@ -175,7 +255,7 @@ func Test_prsWithClosedLinkedIssue(t *testing.T) {
 					},
 				},
 			},
-			expected: false,
+			keep: false,
 		},
 		{
 			name: "open linked issue",
@@ -186,24 +266,24 @@ func Test_prsWithClosedLinkedIssue(t *testing.T) {
 					},
 				},
 			},
-			expected: true,
+			keep: true,
 		},
 		{
 			name: "no linked issue",
 			pr: ghPullRequest{
 				LinkedIssues: []ghIssue{},
 			},
-			expected: true,
+			keep: true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, prsWithClosedLinkedIssue()(test.pr))
+			assert.Equal(t, test.keep, prsWithoutClosedLinkedIssue()(test.pr))
 		})
 	}
 }
 
-func Test_prsWithOpenLinkedIssue(t *testing.T) {
+func Test_prsWithoutOpenLinkedIssue(t *testing.T) {
 
 	tests := []struct {
 		name     string
@@ -243,7 +323,7 @@ func Test_prsWithOpenLinkedIssue(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, prsWithOpenLinkedIssue()(test.pr))
+			assert.Equal(t, test.expected, prsWithoutOpenLinkedIssue()(test.pr))
 		})
 	}
 }

--- a/chronicle/release/summarizer/github/summarizer_test.go
+++ b/chronicle/release/summarizer/github/summarizer_test.go
@@ -1,7 +1,10 @@
 package github
 
 import (
+	"github.com/anchore/chronicle/chronicle/release/change"
+	"github.com/anchore/chronicle/internal/git"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -34,6 +37,351 @@ func Test_extractGithubUserAndRepo(t *testing.T) {
 			user, repo := extractGithubUserAndRepo(test.url)
 			assert.Equal(t, test.user, user, "bad user")
 			assert.Equal(t, test.repo, repo, "bad repo")
+		})
+	}
+}
+
+func Test_issueFilters(t *testing.T) {
+	patch := change.NewType("patch", change.SemVerPatch)
+	feature := change.NewType("added-feature", change.SemVerMinor)
+	breaking := change.NewType("breaking-change", change.SemVerMajor)
+
+	changeTypeSet := change.TypeSet{
+		"bug":             patch,
+		"fix":             patch,
+		"feature":         feature,
+		"breaking":        breaking,
+		"removed":         breaking,
+		"breaking-change": breaking,
+	}
+
+	timeStart := time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC)
+	timeAfter := timeStart.Add(2 * time.Hour)
+	timeBefore := timeStart.Add(-2 * time.Hour)
+	timeEnd := timeStart.Add(5 * time.Hour)
+	timeAfterEnd := timeEnd.Add(3 * time.Hour)
+
+	sinceTag := &git.Tag{
+		Name:      "v0.1.0",
+		Timestamp: timeStart,
+	}
+
+	untilTag := &git.Tag{
+		Name:      "v0.2.0",
+		Timestamp: timeEnd,
+	}
+
+	bugAfterLastRelease := ghIssue{
+		Title:    "bug after last release",
+		Number:   1,
+		ClosedAt: timeAfter,
+		Closed:   true,
+		Labels:   []string{"bug"},
+	}
+
+	bugAtLastRelease := ghIssue{
+		Title:    "bug at (included within) last release",
+		Number:   6,
+		ClosedAt: timeStart,
+		Closed:   true,
+		Labels:   []string{"bug"},
+	}
+
+	bugAtEndTag := ghIssue{
+		Title:    "bug at (included within) end tag",
+		Number:   7,
+		ClosedAt: timeEnd,
+		Closed:   true,
+		Labels:   []string{"bug"},
+	}
+
+	issueWithoutLabelAfterLastRelease := ghIssue{
+		Title:    "issue without label after last release",
+		Number:   2,
+		ClosedAt: timeAfter,
+		Closed:   true,
+		Labels:   []string{},
+	}
+
+	bugBeforeLastRelease := ghIssue{
+		Title:    "bug before last release",
+		Number:   3,
+		ClosedAt: timeBefore,
+		Closed:   true,
+		Labels:   []string{"bug"},
+	}
+
+	bugAfterEndTag := ghIssue{
+		Title:    "bug after end tag",
+		Number:   4,
+		ClosedAt: timeAfterEnd,
+		Closed:   true,
+		Labels:   []string{"bug"},
+	}
+
+	featureAfterLastRelease := ghIssue{
+		Title:    "feature after last release",
+		Number:   5,
+		ClosedAt: timeAfter,
+		Closed:   true,
+		Labels:   []string{"feature"},
+	}
+
+	input := []ghIssue{
+		// keep
+		bugAfterLastRelease,
+		issueWithoutLabelAfterLastRelease,
+		featureAfterLastRelease,
+		bugAtEndTag, // edge case
+		// not keep
+		bugBeforeLastRelease,
+		bugAfterEndTag,
+		bugAtLastRelease, // edge case
+	}
+	tests := []struct {
+		name           string
+		since          *git.Tag
+		until          *git.Tag
+		config         Config
+		inputIssues    []ghIssue
+		expectedIssues []ghIssue
+	}{
+		{
+			name:  "keep changes between the tags",
+			since: sinceTag,
+			until: untilTag,
+			config: Config{
+				ExcludeLabels:      nil,
+				ChangeTypesByLabel: changeTypeSet,
+			},
+			inputIssues: input,
+			expectedIssues: []ghIssue{
+				bugAfterLastRelease,
+				featureAfterLastRelease,
+				bugAtEndTag,
+			},
+		},
+		{
+			name:  "keep changes after start tag",
+			since: sinceTag,
+			config: Config{
+				ExcludeLabels:      nil,
+				ChangeTypesByLabel: changeTypeSet,
+			},
+			inputIssues: input,
+			expectedIssues: []ghIssue{
+				bugAfterLastRelease,
+				bugAfterEndTag,
+				featureAfterLastRelease,
+				bugAtEndTag,
+			},
+		},
+		{
+			name:  "keep changes after start tag (that are not bugs)",
+			since: sinceTag,
+			config: Config{
+				ExcludeLabels:      []string{"bug"},
+				ChangeTypesByLabel: changeTypeSet,
+			},
+			inputIssues: input,
+			expectedIssues: []ghIssue{
+				featureAfterLastRelease,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.expectedIssues, filterIssues(tt.inputIssues, standardIssueFilters(tt.config, tt.since, tt.until)...))
+		})
+	}
+}
+
+func Test_prFilters(t *testing.T) {
+	patch := change.NewType("patch", change.SemVerPatch)
+	feature := change.NewType("added-feature", change.SemVerMinor)
+	breaking := change.NewType("breaking-change", change.SemVerMajor)
+
+	changeTypeSet := change.TypeSet{
+		"bug":             patch,
+		"fix":             patch,
+		"feature":         feature,
+		"breaking":        breaking,
+		"removed":         breaking,
+		"breaking-change": breaking,
+	}
+
+	timeStart := time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC)
+	timeAfter := timeStart.Add(2 * time.Hour)
+	timeBefore := timeStart.Add(-2 * time.Hour)
+	timeEnd := timeStart.Add(5 * time.Hour)
+	timeAfterEnd := timeEnd.Add(3 * time.Hour)
+
+	sinceTag := &git.Tag{
+		Name:      "v0.1.0",
+		Timestamp: timeStart,
+	}
+
+	untilTag := &git.Tag{
+		Name:      "v0.2.0",
+		Timestamp: timeEnd,
+	}
+
+	prBugAfterLastRelease := ghPullRequest{
+		Title:    "pr bug after starting tag",
+		Number:   1,
+		MergedAt: timeAfter,
+		Labels:   []string{"bug"},
+	}
+
+	prBugAtLastRelease := ghPullRequest{
+		Title:    "pr bug at (within) last release",
+		Number:   10,
+		MergedAt: timeStart,
+		Labels:   []string{"bug"},
+	}
+
+	prBugAtEndTag := ghPullRequest{
+		Title:    "pr bug at (within) end tag",
+		Number:   11,
+		MergedAt: timeEnd,
+		Labels:   []string{"bug"},
+	}
+
+	prAfterLastRelease := ghPullRequest{
+		Title:    "pr after starting tag",
+		Number:   9,
+		MergedAt: timeAfter,
+	}
+
+	prBugBeforeLastRelease := ghPullRequest{
+		Title:    "pr bug before starting tag",
+		Number:   2,
+		MergedAt: timeBefore,
+		Labels:   []string{"bug"},
+	}
+
+	issueClosedAfterLastRelease := ghIssue{
+		Title:    "issue bug (closed after last release)",
+		Number:   4,
+		ClosedAt: timeAfter,
+		Closed:   true,
+		Labels:   []string{"bug"},
+	}
+
+	issueOpen := ghIssue{
+		Title:  "issue bug (open)",
+		Number: 5,
+		Closed: false,
+		Labels: []string{"bug"},
+	}
+
+	prBugAfterLastReleaseWithOpenLinkedIssue := ghPullRequest{
+		Title:        "pr bug after starting tag (w/ open linked issue)",
+		Number:       3,
+		MergedAt:     timeAfter,
+		Labels:       []string{"bug"},
+		LinkedIssues: []ghIssue{issueOpen},
+	}
+
+	prAfterLastReleaseWithOpenLinkedIssue := ghPullRequest{
+		Title:        "pr after starting tag (w/ open linked issue)",
+		Number:       6,
+		MergedAt:     timeAfter,
+		LinkedIssues: []ghIssue{issueOpen},
+	}
+
+	prBugAfterLastReleaseWithClosedLinkedIssue := ghPullRequest{
+		Title:        "pr bug after starting tag (w/ closed linked issue)",
+		Number:       7,
+		MergedAt:     timeAfter,
+		Labels:       []string{"bug"},
+		LinkedIssues: []ghIssue{issueClosedAfterLastRelease},
+	}
+
+	prAfterLastReleaseWithClosedLinkedIssue := ghPullRequest{
+		Title:        "pr after starting tag (w/ closed linked issue)",
+		Number:       8,
+		MergedAt:     timeAfter,
+		LinkedIssues: []ghIssue{issueClosedAfterLastRelease},
+	}
+
+	prFeatureAfterEndTag := ghPullRequest{
+		Title:    "pr feature after end tag",
+		Number:   1,
+		MergedAt: timeAfterEnd,
+		Labels:   []string{"feature"},
+	}
+
+	input := []ghPullRequest{
+		// keep
+		prBugAfterLastRelease,
+		prBugAtEndTag,
+
+		// filter out
+		prAfterLastRelease,
+		prBugAtLastRelease, // edge case
+		prBugBeforeLastRelease,
+		prBugAfterLastReleaseWithOpenLinkedIssue,
+		prAfterLastReleaseWithOpenLinkedIssue,
+		prBugAfterLastReleaseWithClosedLinkedIssue,
+		prAfterLastReleaseWithClosedLinkedIssue,
+		prFeatureAfterEndTag,
+	}
+
+	tests := []struct {
+		name        string
+		since       *git.Tag
+		until       *git.Tag
+		config      Config
+		inputPrs    []ghPullRequest
+		expectedPrs []ghPullRequest
+	}{
+		{
+			name:  "keep changes between the tags",
+			since: sinceTag,
+			until: untilTag,
+			config: Config{
+				ExcludeLabels:      nil,
+				ChangeTypesByLabel: changeTypeSet,
+			},
+			inputPrs: input,
+			expectedPrs: []ghPullRequest{
+				prBugAfterLastRelease,
+				prBugAtEndTag,
+			},
+		},
+		{
+			name:  "keep changes after start tag",
+			since: sinceTag,
+			config: Config{
+				ExcludeLabels:      nil,
+				ChangeTypesByLabel: changeTypeSet,
+			},
+			inputPrs: input,
+			expectedPrs: []ghPullRequest{
+				prBugAfterLastRelease,
+				prBugAtEndTag,
+				prFeatureAfterEndTag,
+			},
+		},
+		{
+			name:  "keep only added features after start tag",
+			since: sinceTag,
+			config: Config{
+				ExcludeLabels:      []string{"bug"},
+				ChangeTypesByLabel: changeTypeSet,
+			},
+			inputPrs: input,
+			expectedPrs: []ghPullRequest{
+				prFeatureAfterEndTag,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.expectedPrs, filterPRs(tt.inputPrs, standardPrFilters(tt.config, tt.since, tt.until)...))
 		})
 	}
 }


### PR DESCRIPTION
Follow up from https://github.com/anchore/chronicle/pull/27 ; we shouldn't consider PRs from the last release when making the changelog for this release.