### PR TITLE
Add feature to require issues to have linked PRs

### DIFF
--- a/.chronicle.yaml
+++ b/.chronicle.yaml
@@ -1,4 +1,2 @@
-github:
-  include-prs: true
 log:
   level: trace

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ COVER_REPORT = $(RESULTSDIR)/unit-coverage-details.txt
 COVER_TOTAL = $(RESULTSDIR)/unit-coverage-summary.txt
 LINTCMD = $(TEMPDIR)/golangci-lint run --tests=false --timeout=2m --config .golangci.yaml
 # the quality gate lower threshold for unit test total % coverage (by function statements)
-COVERAGE_THRESHOLD := 25
+COVERAGE_THRESHOLD := 50
 # CI cache busting values; change these if you want CI to not use previous stored cache
 FIXTURE_CACHE_BUSTER = "88738d2f"
 

--- a/README.md
+++ b/README.md
@@ -8,19 +8,32 @@
 [![Slack Invite](https://img.shields.io/badge/Slack-Join-blue?logo=slack)](https://anchore.com/slack)
 
 
-A fast changelog generator that sources changes from GitHub PRs and issues, organized by labels.
+**A fast changelog generator that sources changes from GitHub PRs and issues, organized by labels.**
 
+
+Create a changelog from the last GitHib release until the current git HEAD tag/commit for the git repo in the current directory:
 ```bash
-# create a changelog from the last GitHib release until the current git HEAD tag/commit
-# for the git repo in the current directory
 chronicle 
+```
 
-# create a changelog with all changes from v0.16.0 until current git HEAD tag/commit
-# for the git repo in the current directory
+Create a changelog with all changes from v0.16.0 until current git HEAD tag/commit for the git repo in the current directory:
+```bash
 chronicle --since-tag v0.16.0
+```
 
-# create a changelog between two specific tags for a repo at the given path
+Create a changelog between two specific tags for a repo at the given path
+```bash
 chronicle --since-tag v0.16.0 --until-tag v0.18.0 ./path/to/git/repo
+```
+
+Create a changelog and guess the release version from the set of changes in the changelog
+```bash
+chronicle --speculate-next-version
+```
+
+Just guess the next release version based on the set of changes (don't create a changelog)
+```bash
+chronicle next-version
 ```
 
 ## Installation
@@ -35,3 +48,154 @@ curl -sSfL https://raw.githubusercontent.com/anchore/chronicle/main/install.sh |
 curl -sSfL https://raw.githubusercontent.com/anchore/chronicle/main/install.sh | sh -s -- -b <DESTINATION_DIR> <RELEASE_VERSION>
 ```
 
+## Configuration
+
+Configuration search paths:
+  - `.chronicle.yaml`
+  - `.chronicle/config.yaml`
+  - `~/.chronicle.yaml`
+  - `<XDG_CONFIG_HOME>/chronicle/config.yaml`
+
+### Default values
+
+Configuration options (example values are the default):
+
+```yaml
+# the output format of the changelog
+# same as -o, --output, and CHRONICLE_OUTPUT env var
+output: md
+
+# suppress all logging output
+# same as -q ; CHRONICLE_QUIET env var
+quiet: false
+
+# all logging options
+log:
+  # use structured logging
+  # same as CHRONICLE_LOG_STRUCTURED env var
+  structured: false
+
+  # the log level
+  # same as CHRONICLE_LOG_LEVEL env var
+  level: "warn"
+
+  # location to write the log file (default is not to have a log file)
+  # same as CHRONICLE_LOG_FILE env var
+  file: ""
+
+# guess what the next release version is based on the current version and set of changes (cannot be used with --until-tag)
+# same as --speculate-next-version / -n ; CHRONICLE_SPECULATE_NEXT_VERSION env var
+speculate-next-version: true
+
+# override the starting git tag for the changelog (default is to detect the last release automatically)
+# same as --since-tag / -s ; CHRONICLE_SINCE_TAG env var
+since-tag: ""
+
+# override the ending git tag for the changelog (default is to use the tag or commit at git HEAD)
+# same as --until-tag / -u ; CHRONICLE_SINCE_TAG env var
+until-tag: ""
+
+# if the current release version is < v1.0 then breaking changes will bump the minor version field
+# same as CHRONICLE_ENFORCE_V0 env var
+enforce-v0: false
+
+# the title used for the changelog
+# same as CHRONICLE_TITLE
+title: Changelog
+
+# all github-related settings
+github:
+  
+  # the github host to use (override for github enterprise deployments)
+  # same as CHRONICLE_GITHUB_HOST env var
+  host: github.com
+  
+  # do not consider any issues or PRs with any of the given labels
+  # same as CHRONICLE_GITHUB_EXCLUDE_LABELS env var
+  exclude-labels:
+    - duplicate
+    - question
+    - invalid
+    - wontfix
+    - wont-fix
+    - release-ignore
+    - changelog-ignore
+    - ignore
+  
+  # consider merged PRs as candidate changelog entries (must have a matching label from a 'github.changes' entry)
+  # same as CHRONICLE_GITHUB_INCLUDE_PRS env var
+  include-prs: true
+
+  # consider closed issues as candidate changelog entries (must have a matching label from a 'github.changes' entry)
+  # same as CHRONICLE_GITHUB_INCLUDE_ISSUES env var
+  include-issues: true
+
+  # issues can only be considered for changelog candidates if they have linked PRs that are merged (note: does NOT require github.include-issues to be set)
+  # same as CHRONICLE_GITHUB_ISSUES_REQUIRE_LINKED_PRS env var
+  issues-require-linked-prs: false
+  
+  # list of definitions of what labels applied to issues or PRs constitute a changelog entry. These entries also dictate 
+  # the changelog section, the changelog title, and the semver field that best represents the class of change.
+  # note: cannot be set via environment variables
+  changes: [...<list of entries>...] # See "Default GitHub change definitions" section for more details
+
+```
+
+### Default GitHub change definitions
+
+The `github.changes` configurable is a list of mappings, each that take the following fields:
+
+- `name`: _[string]_ singular, lowercase, hyphen-separated (no spaces) name that best represents the change (e.g. "breaking-change", "security", "added-feature", "enhancement", "new-feature", etc).
+- `title`: _[string]_ title of the section in the changelog listing all entries.
+- `semver-field`: _[string]_ change entries will bump the respective semver field when guessing the next release version. Allowable values: `major`, `minor`, or `patch`.
+- `labels`: _[list of strings]_ all issue or PR labels that should match this change section.
+
+The default value for `github.changes` is:
+
+```yaml
+- name: security-fixes
+  title: Security Fixes
+  semver-field: patch
+  labels:
+    - security
+    - vulnerability
+  
+- name: added-feature
+  title: Added Features
+  semver-field: minor
+  labels:
+    - enhancement
+    - feature
+    - minor
+  
+- name: bug-fix
+  title: Bug Fixes
+  semver-field: patch
+  labels:
+    - bug
+    - fix
+    - bug-fix
+    - patch
+  
+- name: breaking-feature
+  title: Breaking Changes
+  semver-field: major
+  labels:
+    - breaking
+    - backwards-incompatible
+    - breaking-change
+    - breaking-feature
+    - major
+    
+- name: removed-feature
+  title: Removed Features
+  semver-field: major
+  labels:
+    - removed
+  
+- name: deprecated-feature
+  title: Deprecated Features
+  semver-field: minor
+  labels:
+    - deprecated
+```

--- a/chronicle/release/summarizer/github/gh_pull_request.go
+++ b/chronicle/release/summarizer/github/gh_pull_request.go
@@ -99,6 +99,18 @@ func prsWithoutClosedLinkedIssue() prFilter {
 	}
 }
 
+func prsWithClosedLinkedIssue() prFilter {
+	return func(pr ghPullRequest) bool {
+		for _, i := range pr.LinkedIssues {
+			if i.Closed {
+				return true
+			}
+		}
+		log.Tracef("PR #%d filtered out: does not have a closed linked issue", pr.Number)
+		return false
+	}
+}
+
 func prsWithoutOpenLinkedIssue() prFilter {
 	return func(pr ghPullRequest) bool {
 		for _, i := range pr.LinkedIssues {

--- a/internal/config/github.go
+++ b/internal/config/github.go
@@ -9,18 +9,19 @@ import (
 )
 
 type githubSummarizer struct {
-	Host          string         `yaml:"host" json:"host" mapstructure:"host"`
-	Changes       []githubChange `yaml:"changes" json:"changes" mapstructure:"changes"`
-	ExcludeLabels []string       `yaml:"exclude-labels" json:"exclude-labels" mapstructure:"exclude-labels"`
-	IncludePRs    bool           `yaml:"include-prs" json:"include-prs" mapstructure:"include-prs"`
-	IncludeIssues bool           `yaml:"include-issues" json:"include-issues" mapstructure:"include-issues"`
+	Host                  string         `yaml:"host" json:"host" mapstructure:"host"`
+	ExcludeLabels         []string       `yaml:"exclude-labels" json:"exclude-labels" mapstructure:"exclude-labels"`
+	IncludePRs            bool           `yaml:"include-prs" json:"include-prs" mapstructure:"include-prs"`
+	IncludeIssues         bool           `yaml:"include-issues" json:"include-issues" mapstructure:"include-issues"`
+	IssuesRequireLinkedPR bool           `yaml:"issues-require-linked-prs" json:"issues-require-linked-prs" mapstructure:"issues-require-linked-prs"`
+	Changes               []githubChange `yaml:"changes" json:"changes" mapstructure:"changes"`
 }
 
 type githubChange struct {
 	Type       string   `yaml:"name" json:"name" mapstructure:"name"`
 	Title      string   `yaml:"title" json:"title" mapstructure:"title"`
-	Labels     []string `yaml:"labels" json:"labels" mapstructure:"labels"`
 	SemVerKind string   `yaml:"semver-field" json:"semver-field" mapstructure:"semver-field"`
+	Labels     []string `yaml:"labels" json:"labels" mapstructure:"labels"`
 }
 
 func (cfg githubSummarizer) ToGithubConfig() (github.Config, error) {
@@ -36,16 +37,18 @@ func (cfg githubSummarizer) ToGithubConfig() (github.Config, error) {
 		}
 	}
 	return github.Config{
-		Host:               cfg.Host,
-		IncludeIssues:      cfg.IncludeIssues,
-		IncludePRs:         cfg.IncludePRs,
-		ExcludeLabels:      cfg.ExcludeLabels,
-		ChangeTypesByLabel: typeSet,
+		Host:                  cfg.Host,
+		IncludeIssues:         cfg.IncludeIssues,
+		IncludePRs:            cfg.IncludePRs,
+		ExcludeLabels:         cfg.ExcludeLabels,
+		IssuesRequireLinkedPR: cfg.IssuesRequireLinkedPR,
+		ChangeTypesByLabel:    typeSet,
 	}, nil
 }
 
 func (cfg githubSummarizer) loadDefaultValues(v *viper.Viper) {
 	v.SetDefault("github.host", "github.com")
+	v.SetDefault("github.issues-require-linked-prs", false)
 	v.SetDefault("github.include-prs", true)
 	v.SetDefault("github.include-issues", true)
 	v.SetDefault("github.exclude-labels", []string{"duplicate", "question", "invalid", "wontfix", "wont-fix", "release-ignore", "changelog-ignore", "ignore"})


### PR DESCRIPTION
A new `CHRONICLE_GITHUB_ISSUES_REQUIRE_PRS` boolean configurable to optionally only consider issues that have linked PRs that are merged as changelog entry candidates. Additionally adds configuration documentation