### PR TITLE
Add release-vs-tag context for next version selection

### DIFF
--- a/chronicle/release/find_next_version.go
+++ b/chronicle/release/find_next_version.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/anchore/chronicle/internal/git"
+
 	"github.com/anchore/chronicle/chronicle/release/change"
 	"github.com/coreos/go-semver/semver"
 )
 
-func FindNextVersion(currentVersion string, changes change.Changes, enforceV0 bool) (string, error) {
+func FindNextVersion(currentVersion string, changes change.Changes, enforceV0 bool, noChangesBumpsPatch bool) (string, error) {
 	var breaking, feature, patch bool
 	for _, c := range changes {
 		for _, chTy := range c.ChangeTypes {
@@ -46,7 +48,10 @@ func FindNextVersion(currentVersion string, changes change.Changes, enforceV0 bo
 	}
 
 	if v.String() == original.String() {
-		return "", fmt.Errorf("no changes found that affect the version (changes=%d)", len(changes))
+		if !noChangesBumpsPatch {
+			return "", fmt.Errorf("no changes found that affect the version (changes=%d)", len(changes))
+		}
+		v.BumpPatch()
 	}
 
 	prefix := ""
@@ -54,4 +59,45 @@ func FindNextVersion(currentVersion string, changes change.Changes, enforceV0 bo
 		prefix = "v"
 	}
 	return prefix + v.String(), nil
+}
+
+func FindNextUniqueVersion(currentVersion string, changes change.Changes, enforceV0 bool, noChangesBumpsPatch bool, repoPath string) (string, string, error) {
+	nextReleaseVersion, err := FindNextVersion(currentVersion, changes, enforceV0, noChangesBumpsPatch)
+	if err != nil {
+		return "", "", err
+	}
+
+	var nextSemanticVersion = nextReleaseVersion
+
+	tags, err := git.TagsFromLocal(repoPath)
+	if err != nil {
+		return "", "", err
+	}
+retry:
+	for {
+		for _, t := range tags {
+			if t.Name == nextReleaseVersion {
+				// looks like there is already a tag for this speculative release, let's choose a patch variant of this
+				verObj, err := semver.NewVersion(strings.TrimLeft(nextReleaseVersion, "v"))
+				if err != nil {
+					return "", "", err
+				}
+				verObj.BumpPatch()
+
+				var prefix string
+				if strings.HasPrefix(nextReleaseVersion, "v") {
+					prefix = "v"
+				}
+
+				releaseVersionCandidate := prefix + verObj.String()
+
+				nextReleaseVersion = releaseVersionCandidate
+				continue retry
+			}
+		}
+		// we've checked that there are no existing tags that match the next release
+		break
+	}
+
+	return nextReleaseVersion, nextSemanticVersion, nil
 }

--- a/chronicle/release/find_next_version_test.go
+++ b/chronicle/release/find_next_version_test.go
@@ -21,12 +21,13 @@ func TestFindNextVersion(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		release   string
-		changes   change.Changes
-		enforceV0 bool
-		want      string
-		wantErr   require.ErrorAssertionFunc
+		name                string
+		release             string
+		changes             change.Changes
+		enforceV0           bool
+		bumpPatchOnNoChange bool
+		want                string
+		wantErr             require.ErrorAssertionFunc
 	}{
 		{
 			name:    "bump major version",
@@ -101,14 +102,26 @@ func TestFindNextVersion(t *testing.T) {
 			want: "0.1.6",
 		},
 		{
-			name:    "honor no prefix",
-			release: "0.1.5",
+			name:                "no changes -- bump patch",
+			release:             "0.1.5",
+			bumpPatchOnNoChange: true,
 			changes: []change.Change{
 				{
-					ChangeTypes: []change.Type{patchChange},
+					ChangeTypes: []change.Type{},
 				},
 			},
 			want: "0.1.6",
+		},
+		{
+			name:                "no changes -- error",
+			release:             "0.1.5",
+			bumpPatchOnNoChange: false,
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{},
+				},
+			},
+			wantErr: require.Error,
 		},
 		{
 			name:    "error on bad version",
@@ -121,7 +134,7 @@ func TestFindNextVersion(t *testing.T) {
 			if tt.wantErr == nil {
 				tt.wantErr = require.NoError
 			}
-			got, err := FindNextVersion(tt.release, tt.changes, tt.enforceV0)
+			got, err := FindNextVersion(tt.release, tt.changes, tt.enforceV0, tt.bumpPatchOnNoChange)
 			tt.wantErr(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/cmd/next_version.go
+++ b/cmd/next_version.go
@@ -63,12 +63,12 @@ func runNextVersion(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	nextVersion, err := release.FindNextVersion(lastRelease.Version, description.Changes, appConfig.EnforceV0)
+	nextUniqueVersion, _, err := release.FindNextUniqueVersion(lastRelease.Version, description.Changes, appConfig.EnforceV0, true, appConfig.CliOptions.RepoPath)
 	if err != nil {
 		return err
 	}
 
-	_, err = os.Stdout.Write([]byte(nextVersion))
+	_, err = os.Stdout.Write([]byte(nextUniqueVersion))
 
 	return err
 }


### PR DESCRIPTION
In cases where there is already a release for a speculative release version, now that version will be skipped and the next best patch version will be used.