### PR TITLE
feat: hide issues closed as unplanned with no linked PRs

### DIFF
--- a/chronicle/release/releasers/github/gh_issue_test.go
+++ b/chronicle/release/releasers/github/gh_issue_test.go
@@ -238,3 +238,86 @@ func Test_issuesWithoutLabel(t *testing.T) {
 		})
 	}
 }
+
+func Test_excludeIssuesNotPlanned(t *testing.T) {
+	issue1 := ghIssue{
+		Title:      "Issue 1",
+		Number:     1,
+		URL:        "issue-1-url",
+		Closed:     true,
+		NotPlanned: true,
+	}
+
+	issue2 := ghIssue{
+		Title:  "Issue 2",
+		Number: 2,
+		URL:    "issue-2-url",
+	}
+
+	issue3 := ghIssue{
+		Title:      "Issue 3 no links",
+		Number:     3,
+		URL:        "issue-3-url",
+		Closed:     true,
+		NotPlanned: true,
+	}
+
+	prWithLinkedIssues1 := ghPullRequest{
+		Title:  "pr 1 with linked issues",
+		Number: 1,
+		LinkedIssues: []ghIssue{
+			issue1,
+		},
+	}
+
+	prWithLinkedIssues2 := ghPullRequest{
+		Title:  "pr 2 with linked issues",
+		Number: 2,
+		Author: "some-author-2",
+		URL:    "some-url-2",
+		LinkedIssues: []ghIssue{
+			issue2,
+		},
+	}
+
+	prWithoutLinkedIssues1 := ghPullRequest{
+		Title:  "pr 3 without linked issues",
+		Number: 3,
+		Author: "some-author",
+		URL:    "some-url",
+	}
+
+	tests := []struct {
+		name     string
+		config   Config
+		prs      []ghPullRequest
+		issues   []ghIssue
+		expected []ghIssue
+	}{
+		{
+			name:   "includes author for issues",
+			config: Config{},
+			prs: []ghPullRequest{
+				prWithLinkedIssues1,
+				prWithLinkedIssues2,
+				prWithoutLinkedIssues1,
+			},
+			issues: []ghIssue{
+				issue1,
+				issue2,
+				issue3,
+			},
+			expected: []ghIssue{
+				issue1,
+				issue2,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			filtered := filterIssues(test.issues, excludeIssuesNotPlanned(test.prs))
+			assert.Equal(t, test.expected, filtered)
+		})
+	}
+}

--- a/chronicle/release/releasers/github/gh_issue_test.go
+++ b/chronicle/release/releasers/github/gh_issue_test.go
@@ -295,7 +295,7 @@ func Test_excludeIssuesNotPlanned(t *testing.T) {
 		expected []ghIssue
 	}{
 		{
-			name:   "includes author for issues",
+			name:   "excludes not planned issues with no linked PRs",
 			config: Config{},
 			prs: []ghPullRequest{
 				prWithLinkedIssues1,

--- a/chronicle/release/releasers/github/summarizer.go
+++ b/chronicle/release/releasers/github/summarizer.go
@@ -20,15 +20,16 @@ const (
 var _ release.Summarizer = (*Summarizer)(nil)
 
 type Config struct {
-	Host                   string
-	IncludeIssuePRAuthors  bool
-	IncludeIssues          bool
-	IncludeIssuePRs        bool
-	IncludePRs             bool
-	ExcludeLabels          []string
-	ChangeTypesByLabel     change.TypeSet
-	IssuesRequireLinkedPR  bool
-	ConsiderPRMergeCommits bool
+	Host                            string
+	IncludeIssuePRAuthors           bool
+	IncludeIssues                   bool
+	IncludeIssuePRs                 bool
+	IncludeIssuesClosedAsNotPlanned bool
+	IncludePRs                      bool
+	ExcludeLabels                   []string
+	ChangeTypesByLabel              change.TypeSet
+	IssuesRequireLinkedPR           bool
+	ConsiderPRMergeCommits          bool
 }
 
 type Summarizer struct {
@@ -169,6 +170,10 @@ func (s *Summarizer) Changes(sinceRef, untilRef string) ([]change.Change, error)
 			allClosedIssues, err := fetchClosedIssues(s.userName, s.repoName)
 			if err != nil {
 				return nil, err
+			}
+
+			if !s.config.IncludeIssuesClosedAsNotPlanned {
+				allClosedIssues = filterIssues(allClosedIssues, excludeIssuesNotPlanned(allMergedPRs))
 			}
 
 			log.Debugf("total closed issues discovered: %d", len(allClosedIssues))

--- a/internal/config/github.go
+++ b/internal/config/github.go
@@ -10,15 +10,16 @@ import (
 )
 
 type githubSummarizer struct {
-	Host                   string         `yaml:"host" json:"host" mapstructure:"host"`
-	ExcludeLabels          []string       `yaml:"exclude-labels" json:"exclude-labels" mapstructure:"exclude-labels"`
-	IncludeIssuePRAuthors  bool           `yaml:"include-issue-pr-authors" json:"include-issue-pr-authors" mapstructure:"include-issue-pr-authors"`
-	IncludeIssuePRs        bool           `yaml:"include-issue-prs" json:"include-issue-prs" mapstructure:"include-issue-prs"`
-	IncludePRs             bool           `yaml:"include-prs" json:"include-prs" mapstructure:"include-prs"`
-	IncludeIssues          bool           `yaml:"include-issues" json:"include-issues" mapstructure:"include-issues"`
-	IssuesRequireLinkedPR  bool           `yaml:"issues-require-linked-prs" json:"issues-require-linked-prs" mapstructure:"issues-require-linked-prs"`
-	ConsiderPRMergeCommits bool           `yaml:"consider-pr-merge-commits" json:"consider-pr-merge-commits" mapstructure:"consider-pr-merge-commits"`
-	Changes                []githubChange `yaml:"changes" json:"changes" mapstructure:"changes"`
+	Host                            string         `yaml:"host" json:"host" mapstructure:"host"`
+	ExcludeLabels                   []string       `yaml:"exclude-labels" json:"exclude-labels" mapstructure:"exclude-labels"`
+	IncludeIssuePRAuthors           bool           `yaml:"include-issue-pr-authors" json:"include-issue-pr-authors" mapstructure:"include-issue-pr-authors"`
+	IncludeIssuePRs                 bool           `yaml:"include-issue-prs" json:"include-issue-prs" mapstructure:"include-issue-prs"`
+	IncludeIssuesClosedAsNotPlanned bool           `yaml:"include-issues-not-planned" json:"include-issues-not-planned" mapstructure:"include-issues-not-planned"`
+	IncludePRs                      bool           `yaml:"include-prs" json:"include-prs" mapstructure:"include-prs"`
+	IncludeIssues                   bool           `yaml:"include-issues" json:"include-issues" mapstructure:"include-issues"`
+	IssuesRequireLinkedPR           bool           `yaml:"issues-require-linked-prs" json:"issues-require-linked-prs" mapstructure:"issues-require-linked-prs"`
+	ConsiderPRMergeCommits          bool           `yaml:"consider-pr-merge-commits" json:"consider-pr-merge-commits" mapstructure:"consider-pr-merge-commits"`
+	Changes                         []githubChange `yaml:"changes" json:"changes" mapstructure:"changes"`
 }
 
 type githubChange struct {
@@ -41,15 +42,16 @@ func (cfg githubSummarizer) ToGithubConfig() (github.Config, error) {
 		}
 	}
 	return github.Config{
-		Host:                   cfg.Host,
-		IncludeIssuePRAuthors:  cfg.IncludeIssuePRAuthors,
-		IncludeIssuePRs:        cfg.IncludeIssuePRs,
-		IncludeIssues:          cfg.IncludeIssues,
-		IncludePRs:             cfg.IncludePRs,
-		ExcludeLabels:          cfg.ExcludeLabels,
-		IssuesRequireLinkedPR:  cfg.IssuesRequireLinkedPR,
-		ConsiderPRMergeCommits: cfg.ConsiderPRMergeCommits,
-		ChangeTypesByLabel:     typeSet,
+		Host:                            cfg.Host,
+		IncludeIssuePRAuthors:           cfg.IncludeIssuePRAuthors,
+		IncludeIssuePRs:                 cfg.IncludeIssuePRs,
+		IncludeIssues:                   cfg.IncludeIssues,
+		IncludeIssuesClosedAsNotPlanned: cfg.IncludeIssuesClosedAsNotPlanned,
+		IncludePRs:                      cfg.IncludePRs,
+		ExcludeLabels:                   cfg.ExcludeLabels,
+		IssuesRequireLinkedPR:           cfg.IssuesRequireLinkedPR,
+		ConsiderPRMergeCommits:          cfg.ConsiderPRMergeCommits,
+		ChangeTypesByLabel:              typeSet,
 	}, nil
 }
 
@@ -61,6 +63,7 @@ func (cfg githubSummarizer) loadDefaultValues(v *viper.Viper) {
 	v.SetDefault("github.include-issue-pr-authors", true)
 	v.SetDefault("github.include-issue-prs", true)
 	v.SetDefault("github.include-issues", true)
+	v.SetDefault("github.include-issues-not-planned", false)
 	v.SetDefault("github.exclude-labels", []string{"duplicate", "question", "invalid", "wontfix", "wont-fix", "release-ignore", "changelog-ignore", "ignore"})
 	v.SetDefault("github.changes", []githubChange{
 		{


### PR DESCRIPTION
This PR changes the behavior slightly such that issues closed as unplanned with no linked PRs are not included by default in the output.