### PR TITLE
feat: add section for additional changes which do not have change types

### DIFF
--- a/chronicle/release/change/change.go
+++ b/chronicle/release/change/change.go
@@ -26,6 +26,9 @@ type Reference struct {
 
 // ByChangeType returns the set of changes that match one of the given change types.
 func (s Changes) ByChangeType(types ...Type) (result Changes) {
+	if len(types) == 0 {
+		return nil
+	}
 	for _, summary := range s {
 		if ContainsAny(types, summary.ChangeTypes) || (len(summary.ChangeTypes) == 0 && types[0].Name == UnlabeledPRs) {
 			result = append(result, summary)

--- a/chronicle/release/change/change.go
+++ b/chronicle/release/change/change.go
@@ -4,6 +4,8 @@ import (
 	"time"
 )
 
+const UnlabeledPRs = "unlabeled-prs"
+
 type Changes []Change
 
 // Change represents the smallest unit within a release that can be summarized.
@@ -25,7 +27,7 @@ type Reference struct {
 // ByChangeType returns the set of changes that match one of the given change types.
 func (s Changes) ByChangeType(types ...Type) (result Changes) {
 	for _, summary := range s {
-		if ContainsAny(types, summary.ChangeTypes) {
+		if ContainsAny(types, summary.ChangeTypes) || (len(summary.ChangeTypes) == 0 && types[0].Name == UnlabeledPRs) {
 			result = append(result, summary)
 		}
 	}

--- a/chronicle/release/change/change.go
+++ b/chronicle/release/change/change.go
@@ -4,7 +4,8 @@ import (
 	"time"
 )
 
-const UnlabeledPRs = "unlabeled-prs"
+var UnknownType = NewType("unknown", SemVerUnknown)
+var UnknownTypes = []Type{UnknownType}
 
 type Changes []Change
 
@@ -26,11 +27,8 @@ type Reference struct {
 
 // ByChangeType returns the set of changes that match one of the given change types.
 func (s Changes) ByChangeType(types ...Type) (result Changes) {
-	if len(types) == 0 {
-		return nil
-	}
 	for _, summary := range s {
-		if ContainsAny(types, summary.ChangeTypes) || (len(summary.ChangeTypes) == 0 && types[0].Name == UnlabeledPRs) {
+		if ContainsAny(types, summary.ChangeTypes) {
 			result = append(result, summary)
 		}
 	}

--- a/chronicle/release/releasers/github/gh_issue.go
+++ b/chronicle/release/releasers/github/gh_issue.go
@@ -117,6 +117,17 @@ func issuesWithoutLabel(labels ...string) issueFilter {
 	}
 }
 
+func issuesWithChangeTypes(config Config) issueFilter {
+	return func(issue ghIssue) bool {
+		changeTypes := config.ChangeTypesByLabel.ChangeTypes(issue.Labels...)
+		keep := len(changeTypes) > 0
+		if !keep {
+			log.Tracef("issue #%d filtered out: no change types", issue.Number)
+		}
+		return keep
+	}
+}
+
 // nolint:funlen
 func fetchClosedIssues(user, repo string) ([]ghIssue, error) {
 	src := oauth2.StaticTokenSource(

--- a/chronicle/release/releasers/github/gh_issue_test.go
+++ b/chronicle/release/releasers/github/gh_issue_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/chronicle/chronicle/release/change"
 )
 
 func Test_issuesAtOrAfter(t *testing.T) {
@@ -235,6 +237,49 @@ func Test_issuesWithoutLabel(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.expected, issuesWithoutLabel(test.labels...)(test.issue))
+		})
+	}
+}
+
+func Test_issuesWithChangeTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		issue    ghIssue
+		label    string
+		expected bool
+	}{
+		{
+			name:  "matches on label",
+			label: "positive",
+			issue: ghIssue{
+				Labels: []string{"something-else", "positive"},
+			},
+			expected: true,
+		},
+		{
+			name:  "does not match on label",
+			label: "positive",
+			issue: ghIssue{
+				Labels: []string{"something-else", "negative"},
+			},
+			expected: false,
+		},
+		{
+			name:  "does not have change types",
+			label: "positive",
+			issue: ghIssue{
+				Labels: []string{},
+			},
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, issuesWithChangeTypes(Config{
+				ChangeTypesByLabel: change.TypeSet{
+					test.label: change.NewType(test.label, change.SemVerMinor),
+				},
+			})(test.issue))
 		})
 	}
 }

--- a/chronicle/release/releasers/github/summarizer_test.go
+++ b/chronicle/release/releasers/github/summarizer_test.go
@@ -936,12 +936,7 @@ func Test_createChangesFromIssues(t *testing.T) {
 			changes := createChangesFromIssues(tt.config, tt.inputPrs, tt.issues)
 			if !reflect.DeepEqual(tt.expectedChanges, changes) {
 				// print out a JSON diff
-				toJson := func(changes []change.Change) string {
-					out, err := json.Marshal(changes)
-					require.NoError(t, err)
-					return string(out)
-				}
-				assert.JSONEq(t, toJson(tt.expectedChanges), toJson(changes))
+				assert.JSONEq(t, toJson(t, tt.expectedChanges), toJson(t, changes))
 			}
 		})
 	}
@@ -1011,7 +1006,7 @@ func Test_changesFromUnlabeledPRs(t *testing.T) {
 			expectedChanges: []change.Change{
 				{
 					Text:        "pr without labels",
-					ChangeTypes: nil,
+					ChangeTypes: change.UnknownTypes,
 					Timestamp:   timeStart,
 					References: []change.Reference{
 						{
@@ -1028,7 +1023,7 @@ func Test_changesFromUnlabeledPRs(t *testing.T) {
 				},
 				{
 					Text:        "pr without labels 2",
-					ChangeTypes: nil,
+					ChangeTypes: change.UnknownTypes,
 					Timestamp:   timeStart,
 					References: []change.Reference{
 						{
@@ -1049,7 +1044,17 @@ func Test_changesFromUnlabeledPRs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.ElementsMatch(t, tt.expectedChanges, changesFromUnlabeledPRs(tt.config, tt.inputPrs, sinceTag, nil))
+			changes := changesFromUnlabeledPRs(tt.config, tt.inputPrs, sinceTag, nil, nil)
+			if !reflect.DeepEqual(tt.expectedChanges, changes) {
+				// print out a JSON diff
+				assert.JSONEq(t, toJson(t, tt.expectedChanges), toJson(t, changes))
+			}
 		})
 	}
+}
+
+func toJson(t *testing.T, changes []change.Change) string {
+	out, err := json.Marshal(changes)
+	require.NoError(t, err)
+	return string(out)
 }

--- a/chronicle/release/releasers/github/summarizer_test.go
+++ b/chronicle/release/releasers/github/summarizer_test.go
@@ -946,3 +946,110 @@ func Test_createChangesFromIssues(t *testing.T) {
 		})
 	}
 }
+
+func Test_changesFromUnlabeledPRs(t *testing.T) {
+	timeStart := time.Date(2021, time.September, 16, 19, 34, 0, 0, time.UTC)
+
+	sinceTag := &git.Tag{
+		Name:      "v0.1.0",
+		Timestamp: timeStart.Add(-5 * time.Hour),
+	}
+
+	prWithLabels := ghPullRequest{
+		Title:    "pr with labels",
+		MergedAt: timeStart,
+		Number:   3,
+		Labels:   []string{"bug"},
+		Author:   "nobody",
+		URL:      "no-url",
+	}
+
+	prWithLabels2 := ghPullRequest{
+		Title:    "pr with labels 2",
+		MergedAt: timeStart,
+		Number:   4,
+		Labels:   []string{"another-label"},
+		Author:   "nobody",
+		URL:      "no-url",
+	}
+
+	prWithoutLabels := ghPullRequest{
+		MergedAt: timeStart,
+		Title:    "pr without labels",
+		Number:   6,
+		Author:   "some-author",
+		URL:      "some-url",
+	}
+
+	prWithoutLabels2 := ghPullRequest{
+		MergedAt: timeStart,
+		Title:    "pr without labels 2",
+		Number:   7,
+		Author:   "some-author-2",
+		URL:      "some-url-2",
+	}
+
+	tests := []struct {
+		name            string
+		config          Config
+		inputPrs        []ghPullRequest
+		expectedChanges []change.Change
+	}{
+		{
+			name: "includes only unlabeled PRs",
+			config: Config{
+				Host: "some-host",
+			},
+			inputPrs: []ghPullRequest{
+				// filter
+				prWithLabels,
+				prWithLabels2,
+				// keep
+				prWithoutLabels,
+				prWithoutLabels2,
+			},
+			expectedChanges: []change.Change{
+				{
+					Text:        "pr without labels",
+					ChangeTypes: nil,
+					Timestamp:   timeStart,
+					References: []change.Reference{
+						{
+							Text: "PR #6",
+							URL:  "some-url",
+						},
+						{
+							Text: "some-author",
+							URL:  "https://some-host/some-author",
+						},
+					},
+					EntryType: "githubPR",
+					Entry:     prWithoutLabels,
+				},
+				{
+					Text:        "pr without labels 2",
+					ChangeTypes: nil,
+					Timestamp:   timeStart,
+					References: []change.Reference{
+						{
+							Text: "PR #7",
+							URL:  "some-url-2",
+						},
+						{
+							Text: "some-author-2",
+							URL:  "https://some-host/some-author-2",
+						},
+					},
+					EntryType: "githubPR",
+					Entry:     prWithoutLabels2,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.expectedChanges, changesFromUnlabeledPRs(tt.config, tt.inputPrs, sinceTag, nil))
+		})
+	}
+}

--- a/cmd/create_github_worker.go
+++ b/cmd/create_github_worker.go
@@ -11,10 +11,7 @@ import (
 )
 
 func createChangelogFromGithub() (*release.Release, *release.Description, error) {
-	ghConfig, err := appConfig.Github.ToGithubConfig()
-	if err != nil {
-		return nil, nil, err
-	}
+	ghConfig := appConfig.Github.ToGithubConfig()
 
 	gitter, err := git.New(appConfig.CliOptions.RepoPath)
 	if err != nil {
@@ -26,10 +23,7 @@ func createChangelogFromGithub() (*release.Release, *release.Description, error)
 		return nil, nil, fmt.Errorf("unable to create summarizer: %w", err)
 	}
 
-	changeTypeTitles, err := getGithubSupportedChanges()
-	if err != nil {
-		return nil, nil, fmt.Errorf("unable to get change type titles from github config: %w", err)
-	}
+	changeTypeTitles := getGithubSupportedChanges()
 
 	var untilTag = appConfig.UntilTag
 	if untilTag == "" {
@@ -64,19 +58,16 @@ func createChangelogFromGithub() (*release.Release, *release.Description, error)
 	return release.ChangelogInfo(summer, changelogConfig)
 }
 
-func getGithubSupportedChanges() ([]change.TypeTitle, error) {
+func getGithubSupportedChanges() []change.TypeTitle {
 	var supportedChanges []change.TypeTitle
 	for _, c := range appConfig.Github.Changes {
 		// TODO: this could be one source of truth upstream
 		k := change.ParseSemVerKind(c.SemVerKind)
-		if k == change.SemVerUnknown {
-			return nil, fmt.Errorf("unable to parse semver kind: %q", c.SemVerKind)
-		}
 		t := change.NewType(c.Type, k)
 		supportedChanges = append(supportedChanges, change.TypeTitle{
 			ChangeType: t,
 			Title:      c.Title,
 		})
 	}
-	return supportedChanges, nil
+	return supportedChanges
 }

--- a/internal/config/github.go
+++ b/internal/config/github.go
@@ -16,6 +16,7 @@ type githubSummarizer struct {
 	IncludeIssuePRs        bool           `yaml:"include-issue-prs" json:"include-issue-prs" mapstructure:"include-issue-prs"`
 	IncludePRs             bool           `yaml:"include-prs" json:"include-prs" mapstructure:"include-prs"`
 	IncludeIssues          bool           `yaml:"include-issues" json:"include-issues" mapstructure:"include-issues"`
+	IncludeUnlabeledPRs    bool           `yaml:"include-unlabeled-prs" json:"include-unlabeled-prs" mapstructure:"include-unlabeled-prs"`
 	IssuesRequireLinkedPR  bool           `yaml:"issues-require-linked-prs" json:"issues-require-linked-prs" mapstructure:"issues-require-linked-prs"`
 	ConsiderPRMergeCommits bool           `yaml:"consider-pr-merge-commits" json:"consider-pr-merge-commits" mapstructure:"consider-pr-merge-commits"`
 	Changes                []githubChange `yaml:"changes" json:"changes" mapstructure:"changes"`
@@ -46,6 +47,7 @@ func (cfg githubSummarizer) ToGithubConfig() (github.Config, error) {
 		IncludeIssuePRs:        cfg.IncludeIssuePRs,
 		IncludeIssues:          cfg.IncludeIssues,
 		IncludePRs:             cfg.IncludePRs,
+		IncludeUnlabeledPRs:    cfg.IncludeUnlabeledPRs,
 		ExcludeLabels:          cfg.ExcludeLabels,
 		IssuesRequireLinkedPR:  cfg.IssuesRequireLinkedPR,
 		ConsiderPRMergeCommits: cfg.ConsiderPRMergeCommits,
@@ -61,6 +63,7 @@ func (cfg githubSummarizer) loadDefaultValues(v *viper.Viper) {
 	v.SetDefault("github.include-issue-pr-authors", true)
 	v.SetDefault("github.include-issue-prs", true)
 	v.SetDefault("github.include-issues", true)
+	v.SetDefault("github.include-unlabeled-prs", true)
 	v.SetDefault("github.exclude-labels", []string{"duplicate", "question", "invalid", "wontfix", "wont-fix", "release-ignore", "changelog-ignore", "ignore"})
 	v.SetDefault("github.changes", []githubChange{
 		{
@@ -97,6 +100,12 @@ func (cfg githubSummarizer) loadDefaultValues(v *viper.Viper) {
 			Type:       "deprecated-feature",
 			Title:      "Deprecated Features",
 			Labels:     []string{"deprecated"},
+			SemVerKind: change.SemVerMinor.String(),
+		},
+		{
+			Type:       change.UnlabeledPRs,
+			Title:      "Unlabeled PRs",
+			Labels:     []string{""},
 			SemVerKind: change.SemVerMinor.String(),
 		},
 	})

--- a/internal/config/github.go
+++ b/internal/config/github.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"fmt"
-
 	"github.com/spf13/viper"
 
 	"github.com/anchore/chronicle/chronicle/release/change"
@@ -30,13 +28,10 @@ type githubChange struct {
 	Labels     []string `yaml:"labels" json:"labels" mapstructure:"labels"`
 }
 
-func (cfg githubSummarizer) ToGithubConfig() (github.Config, error) {
+func (cfg githubSummarizer) ToGithubConfig() github.Config {
 	typeSet := make(change.TypeSet)
 	for _, c := range cfg.Changes {
 		k := change.ParseSemVerKind(c.SemVerKind)
-		if k == change.SemVerUnknown {
-			return github.Config{}, fmt.Errorf("unknown semver field: %q", k)
-		}
 		t := change.NewType(c.Type, k)
 		for _, l := range c.Labels {
 			typeSet[l] = t
@@ -54,7 +49,7 @@ func (cfg githubSummarizer) ToGithubConfig() (github.Config, error) {
 		IssuesRequireLinkedPR:           cfg.IssuesRequireLinkedPR,
 		ConsiderPRMergeCommits:          cfg.ConsiderPRMergeCommits,
 		ChangeTypesByLabel:              typeSet,
-	}, nil
+	}
 }
 
 func (cfg githubSummarizer) loadDefaultValues(v *viper.Viper) {
@@ -106,10 +101,10 @@ func (cfg githubSummarizer) loadDefaultValues(v *viper.Viper) {
 			SemVerKind: change.SemVerMinor.String(),
 		},
 		{
-			Type:       change.UnlabeledPRs,
-			Title:      "Unlabeled PRs",
-			Labels:     []string{""},
-			SemVerKind: change.SemVerMinor.String(),
+			Type:       change.UnknownType.Name,
+			Title:      "Additional Changes",
+			Labels:     []string{},
+			SemVerKind: change.UnknownType.Kind.String(),
 		},
 	})
 }


### PR DESCRIPTION
This PR adds a section for additional changes which do not have change types, currently only including unlabeled PRs, .e.g.:

```
### Additional Changes

- chore: claim artifacthub package ownership from developer-guy [[PR #661](https://github.com/anchore/grype/pull/661)] [[developer-guy](https://github.com/developer-guy)]
- chore: update yardstick to diagnose intermittent quality gate test failures [[PR #1054](https://github.com/anchore/grype/pull/1054)] [[kzantow](https://github.com/kzantow)]
```

Closes #4 