### PR TITLE
Add dependabot for gomod and GH actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
Updates our go module and GH actions used in workflows daily.