### PR TITLE
feat: include closed issues with no labels in Additional Changes section

### DIFF
--- a/chronicle/release/releasers/github/gh_issue.go
+++ b/chronicle/release/releasers/github/gh_issue.go
@@ -144,6 +144,16 @@ func issuesWithChangeTypes(config Config) issueFilter {
 	}
 }
 
+func issuesWithoutLabels() issueFilter {
+	return func(issue ghIssue) bool {
+		keep := len(issue.Labels) == 0
+		if !keep {
+			log.Tracef("issue #%d filtered out: has labels", issue.Number)
+		}
+		return keep
+	}
+}
+
 // nolint:funlen
 func fetchClosedIssues(user, repo string) ([]ghIssue, error) {
 	src := oauth2.StaticTokenSource(

--- a/chronicle/release/releasers/github/gh_issue_test.go
+++ b/chronicle/release/releasers/github/gh_issue_test.go
@@ -241,6 +241,34 @@ func Test_issuesWithoutLabel(t *testing.T) {
 	}
 }
 
+func Test_issuesWithoutLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		issue    ghIssue
+		expected bool
+	}{
+		{
+			name: "omitted when labels",
+			issue: ghIssue{
+				Labels: []string{"something-else", "positive"},
+			},
+			expected: false,
+		},
+		{
+			name: "included with no labels",
+			issue: ghIssue{
+				Labels: []string{},
+			},
+			expected: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, issuesWithoutLabels()(test.issue))
+		})
+	}
+}
+
 func Test_excludeIssuesNotPlanned(t *testing.T) {
 	issue1 := ghIssue{
 		Title:      "Issue 1",

--- a/chronicle/release/releasers/github/gh_pull_request_test.go
+++ b/chronicle/release/releasers/github/gh_pull_request_test.go
@@ -373,14 +373,14 @@ func Test_prsWithoutMergeCommit(t *testing.T) {
 func Test_prsWithChangeTypes(t *testing.T) {
 	tests := []struct {
 		name     string
-		issue    ghPullRequest
+		pr       ghPullRequest
 		label    string
 		expected bool
 	}{
 		{
 			name:  "matches on label",
 			label: "positive",
-			issue: ghPullRequest{
+			pr: ghPullRequest{
 				Labels: []string{"something-else", "positive"},
 			},
 			expected: true,
@@ -388,7 +388,7 @@ func Test_prsWithChangeTypes(t *testing.T) {
 		{
 			name:  "does not match on label",
 			label: "positive",
-			issue: ghPullRequest{
+			pr: ghPullRequest{
 				Labels: []string{"something-else", "negative"},
 			},
 			expected: false,
@@ -396,7 +396,7 @@ func Test_prsWithChangeTypes(t *testing.T) {
 		{
 			name:  "does not have change types",
 			label: "positive",
-			issue: ghPullRequest{
+			pr: ghPullRequest{
 				Labels: []string{},
 			},
 			expected: false,
@@ -408,7 +408,7 @@ func Test_prsWithChangeTypes(t *testing.T) {
 				ChangeTypesByLabel: change.TypeSet{
 					test.label: change.NewType(test.label, change.SemVerMinor),
 				},
-			})(test.issue))
+			})(test.pr))
 		})
 	}
 }
@@ -416,19 +416,19 @@ func Test_prsWithChangeTypes(t *testing.T) {
 func Test_prsWithoutLabels(t *testing.T) {
 	tests := []struct {
 		name     string
-		issue    ghPullRequest
+		pr       ghPullRequest
 		expected bool
 	}{
 		{
 			name: "omitted when labels",
-			issue: ghPullRequest{
+			pr: ghPullRequest{
 				Labels: []string{"something-else", "positive"},
 			},
 			expected: false,
 		},
 		{
 			name: "included with no labels",
-			issue: ghPullRequest{
+			pr: ghPullRequest{
 				Labels: []string{},
 			},
 			expected: true,
@@ -436,7 +436,7 @@ func Test_prsWithoutLabels(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, prsWithoutLabels()(test.issue))
+			assert.Equal(t, test.expected, prsWithoutLabels()(test.pr))
 		})
 	}
 }
@@ -444,17 +444,17 @@ func Test_prsWithoutLabels(t *testing.T) {
 func Test_prsWithoutLinkedIssues(t *testing.T) {
 	tests := []struct {
 		name     string
-		issue    ghPullRequest
+		pr       ghPullRequest
 		expected bool
 	}{
 		{
 			name:     "matches when unlinked",
-			issue:    ghPullRequest{},
+			pr:       ghPullRequest{},
 			expected: true,
 		},
 		{
 			name: "does not match when linked",
-			issue: ghPullRequest{
+			pr: ghPullRequest{
 				LinkedIssues: []ghIssue{
 					{
 						Number: 1,
@@ -467,7 +467,7 @@ func Test_prsWithoutLinkedIssues(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, prsWithoutLinkedIssues()(test.issue))
+			assert.Equal(t, test.expected, prsWithoutLinkedIssues()(test.pr))
 		})
 	}
 }

--- a/internal/config/github.go
+++ b/internal/config/github.go
@@ -15,6 +15,7 @@ type githubSummarizer struct {
 	IncludeIssuesClosedAsNotPlanned bool           `yaml:"include-issues-not-planned" json:"include-issues-not-planned" mapstructure:"include-issues-not-planned"`
 	IncludePRs                      bool           `yaml:"include-prs" json:"include-prs" mapstructure:"include-prs"`
 	IncludeIssues                   bool           `yaml:"include-issues" json:"include-issues" mapstructure:"include-issues"`
+	IncludeUnlabeledIssues          bool           `yaml:"include-unlabeled-issues" json:"include-unlabeled-issues" mapstructure:"include-unlabeled-issues"`
 	IncludeUnlabeledPRs             bool           `yaml:"include-unlabeled-prs" json:"include-unlabeled-prs" mapstructure:"include-unlabeled-prs"`
 	IssuesRequireLinkedPR           bool           `yaml:"issues-require-linked-prs" json:"issues-require-linked-prs" mapstructure:"issues-require-linked-prs"`
 	ConsiderPRMergeCommits          bool           `yaml:"consider-pr-merge-commits" json:"consider-pr-merge-commits" mapstructure:"consider-pr-merge-commits"`
@@ -44,6 +45,7 @@ func (cfg githubSummarizer) ToGithubConfig() github.Config {
 		IncludeIssues:                   cfg.IncludeIssues,
 		IncludeIssuesClosedAsNotPlanned: cfg.IncludeIssuesClosedAsNotPlanned,
 		IncludePRs:                      cfg.IncludePRs,
+		IncludeUnlabeledIssues:          cfg.IncludeUnlabeledIssues,
 		IncludeUnlabeledPRs:             cfg.IncludeUnlabeledPRs,
 		ExcludeLabels:                   cfg.ExcludeLabels,
 		IssuesRequireLinkedPR:           cfg.IssuesRequireLinkedPR,
@@ -61,6 +63,7 @@ func (cfg githubSummarizer) loadDefaultValues(v *viper.Viper) {
 	v.SetDefault("github.include-issue-prs", true)
 	v.SetDefault("github.include-issues", true)
 	v.SetDefault("github.include-issues-not-planned", false)
+	v.SetDefault("github.include-unlabeled-issues", true)
 	v.SetDefault("github.include-unlabeled-prs", true)
 	v.SetDefault("github.exclude-labels", []string{"duplicate", "question", "invalid", "wontfix", "wont-fix", "release-ignore", "changelog-ignore", "ignore"})
 	v.SetDefault("github.changes", []githubChange{


### PR DESCRIPTION
This PR adds issues to the _Additional Changes_ section when they do not have any labels.

Example:
```
### Additional Changes

- Getting many warnings (empty ID, unable to read golang buildinfo, bin parsing) when running grype from command line and directing stderr to file [[Issue #1050](https://github.com/anchore/grype/issues/1050)] [[PR #1067](https://github.com/anchore/grype/pull/1067)] [[kzantow](https://github.com/kzantow)]
- chore: claim artifacthub package ownership from developer-guy [[PR #661](https://github.com/anchore/grype/pull/661)] [[developer-guy](https://github.com/developer-guy)]
- chore: update yardstick to diagnose intermittent quality gate test failures [[PR #1054](https://github.com/anchore/grype/pull/1054)] [[kzantow](https://github.com/kzantow)]
```

Closes #5 