### PR TITLE
chore: run validations on pushes to main

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -2,6 +2,9 @@ name: "Validations"
 on:
   workflow_dispatch:
   pull_request:
+  push:
+    branches:
+      - main
 
 env:
   GO_VERSION: "1.17.x"


### PR DESCRIPTION
This PR causes validation checks to run on pushes to main, which is a requirement for the release quality gate.