### PR TITLE
docs: update the default value for github.changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,4 +198,7 @@ The default value for `github.changes` is:
   semver-field: minor
   labels:
     - deprecated
+
+- name: unknown
+  title: Additional Changes
 ```


### PR DESCRIPTION
This PR just update the documentation to reflect changes to the default GitHub changes section, which includes an "unknown" section for "Additional Changes" which are not labeled.