### PR TITLE
Add ability to output version to a separate file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 CHANGELOG.md
+VERSION
 /test/results
 /dist
 /snapshot

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -58,6 +58,11 @@ func setCreateFlags(flags *pflag.FlagSet) {
 	)
 
 	flags.StringP(
+		"version-file", "", "",
+		"output the current version of the generated changelog to the given file",
+	)
+
+	flags.StringP(
 		"since-tag", "s", "",
 		"tag to start changelog processing from (inclusive)",
 	)
@@ -85,6 +90,7 @@ func bindCreateConfigOptions(flags *pflag.FlagSet) error {
 		"until-tag",
 		"title",
 		"speculate-next-version",
+		"version-file",
 	} {
 		if err := viper.BindPFlag(flag, flags.Lookup(flag)); err != nil {
 			return err
@@ -99,6 +105,16 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	_, description, err := worker()
 	if err != nil {
 		return err
+	}
+
+	if appConfig.VersionFile != "" {
+		f, err := os.OpenFile(appConfig.VersionFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+		if err != nil {
+			return fmt.Errorf("unable to open version file %q: %w", appConfig.VersionFile, err)
+		}
+		if _, err := f.WriteString(description.Version); err != nil {
+			return fmt.Errorf("unable to write version to file %q: %w", appConfig.VersionFile, err)
+		}
 	}
 
 	f := format.FromString(appConfig.Output)

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -33,8 +33,9 @@ type Application struct {
 	Log                  logging          `yaml:"log" json:"log" mapstructure:"log"`                                                          // all logging-related options
 	CliOptions           CliOnlyOptions   `yaml:"-" json:"-"`                                                                                 // all options only available through the CLI (not via env vars or config)
 	SpeculateNextVersion bool             `yaml:"speculate-next-version" json:"speculate-next-version" mapstructure:"speculate-next-version"` // -n, guess the next version based on issues and PRs
-	SinceTag             string           `yaml:"since-tag" json:"since-tag" mapstructure:"since-tag"`
-	UntilTag             string           `yaml:"until-tag" json:"until-tag" mapstructure:"until-tag"`
+	VersionFile          string           `yaml:"version-file" json:"version-file" mapstructure:"version-file"`                               // --version-file, the path to a file containing the version to use for the changelog
+	SinceTag             string           `yaml:"since-tag" json:"since-tag" mapstructure:"since-tag"`                                        // -s, the tag to start the changelog from
+	UntilTag             string           `yaml:"until-tag" json:"until-tag" mapstructure:"until-tag"`                                        // -u, the tag to end the changelog at
 	EnforceV0            bool             `yaml:"enforce-v0" json:"enforce-v0" mapstructure:"enforce-v0"`
 	Title                string           `yaml:"title" json:"title" mapstructure:"title"`
 	Github               githubSummarizer `yaml:"github" json:"github" mapstructure:"github"`


### PR DESCRIPTION
This allows users to be able to specify a separate file to additionally write the determined release version to:
```bash
$ chronicle -n --version-file VERSION > CHANGELOG.md
```

Resulting in:
- "CHANGELOG.md" containing the full changelog for release "v0.70.1" (just like today)
- "VERSION" containing "v0.70.1" (without a newline)
