### PR TITLE
Bump chronicle version to v0.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ bootstrap-tools: $(TEMPDIR)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMPDIR)/ v1.47.2
 	curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMPDIR)/ v0.4.0
 	# we purposefully use the latest version of chronicle released
-	curl -sSfL https://raw.githubusercontent.com/anchore/chronicle/main/install.sh | sh -s -- -b $(TEMPDIR)/
+	curl -sSfL https://raw.githubusercontent.com/anchore/chronicle/main/install.sh | sh -s -- -b $(TEMPDIR)/ v0.6.0
 	.github/scripts/goreleaser-install.sh -b $(TEMPDIR)/ v0.182.1
 	# the only difference between goimports and gosimports is that gosimports removes extra whitespace between import blocks (see https://github.com/golang/go/issues/20818)
 	GOBIN="$(shell realpath $(TEMPDIR))" go install github.com/rinchsan/gosimports/cmd/gosimports@v0.1.5


### PR DESCRIPTION
right now the makefile will pull the latest, but the CI cache will rarely bust the cache. This will bust the cache and pin to a specific version.