### PR TITLE
Add format make target 

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -11,7 +11,7 @@ After cloning do the following:
 
 Checkout `make help` to see what other actions you can take.
 
-The main make tasks for common static analysis and testing are `lint`, `lint-fix`, and `unit`.
+The main make tasks for common static analysis and testing are `lint`, `format`, `lint-fix`, and `unit`.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ TEMPDIR = ./.tmp
 RESULTSDIR = test/results
 COVER_REPORT = $(RESULTSDIR)/unit-coverage-details.txt
 COVER_TOTAL = $(RESULTSDIR)/unit-coverage-summary.txt
-LINTCMD = $(TEMPDIR)/golangci-lint run --tests=false --timeout=2m --config .golangci.yaml
+LINT_CMD = $(TEMPDIR)/golangci-lint run --tests=false --timeout=2m --config .golangci.yaml
 GOIMPORTS_CMD = $(TEMPDIR)/gosimports -local github.com/anchore
 # the quality gate lower threshold for unit test total % coverage (by function statements)
 COVERAGE_THRESHOLD := 50
@@ -110,20 +110,24 @@ lint: ## Run gofmt + golangci lint checks
 	@test -z "$(shell gofmt -l -s .)"
 
 	# run all golangci-lint rules
-	$(LINTCMD)
+	$(LINT_CMD)
 	@[ -z "$(shell $(GOIMPORTS_CMD) -d .)" ] || (echo "goimports needs to be fixed" && false)
 
 	# go tooling does not play well with certain filename characters, ensure the common cases don't result in future "go get" failures
 	$(eval MALFORMED_FILENAMES := $(shell find . | grep -e ':'))
 	@bash -c "[[ '$(MALFORMED_FILENAMES)' == '' ]] || (printf '\nfound unsupported filename characters:\n$(MALFORMED_FILENAMES)\n\n' && false)"
 
-.PHONY: lint-fix
-lint-fix: ## Auto-format all source code + run golangci lint fixers
-	$(call title,Running lint fixers)
+.PHONY: format
+format: ## Auto-format all source code
+	$(call title,Running formatters)
 	gofmt -w -s .
 	$(GOIMPORTS_CMD) -w .
-	$(LINTCMD) --fix
 	go mod tidy
+
+.PHONY: lint-fix
+lint-fix: format  ## Auto-format all source code + run golangci lint fixers
+	$(call title,Running lint fixers)
+	$(LINT_CMD) --fix
 
 .PHONY: check-licenses
 check-licenses:


### PR DESCRIPTION
Splits the format-related tasks in the `lint-fix` target into a new `format` target (which `lint-fix` depends on)