### PR TITLE
Add oss community board auto-add workflow

### DIFF
--- a/.github/workflows/oss-project-board-add.yaml
+++ b/.github/workflows/oss-project-board-add.yaml
@@ -1,0 +1,22 @@
+name: Add Issues and PRs to the Community Board
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+      - labeled
+
+  pull_request:
+    types:
+      - labeled
+      - opened
+      - reopened
+
+jobs:
+
+  add-to-board:
+    uses: "anchore/workflows/.github/workflows/oss-project-board-add.yaml@main"
+    secrets:
+      token: ${{ secrets.OSS_PROJECT_GH_TOKEN }}

--- a/.github/workflows/oss-project-board-add.yaml
+++ b/.github/workflows/oss-project-board-add.yaml
@@ -1,4 +1,4 @@
-name: Add Issues and PRs to the Community Board
+name: Add to OSS board
 
 on:
   issues:
@@ -8,15 +8,9 @@ on:
       - transferred
       - labeled
 
-  pull_request:
-    types:
-      - labeled
-      - opened
-      - reopened
-
 jobs:
 
-  add-to-board:
+  run:
     uses: "anchore/workflows/.github/workflows/oss-project-board-add.yaml@main"
     secrets:
       token: ${{ secrets.OSS_PROJECT_GH_TOKEN }}


### PR DESCRIPTION
Allows for automatically adding issues to the [OSS community board](https://github.com/orgs/anchore/projects/22)