### PR TITLE
fix: continue on tag errors

### DIFF
--- a/internal/git/tag.go
+++ b/internal/git/tag.go
@@ -126,7 +126,8 @@ func TagsFromLocal(repoPath string) ([]Tag, error) {
 
 		c, err := r.CommitObject(t.Hash())
 		if err != nil {
-			return nil, fmt.Errorf("unable to get tag info from commit=%q: %w", t.Hash().String(), err)
+			log.Debugf("unable to get tag '%s' info from commit=%q: %w", t.Name().String(), t.Hash().String(), err)
+			continue
 		}
 
 		tags = append(tags, Tag{


### PR DESCRIPTION
This PR adjusts the behavior when unable to get info from a tag, chronicle will fail to speculate a version and thus things like `syft` `make release` will fail.