### PR TITLE
Upgrade CI workflows

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -1,0 +1,77 @@
+name: "Bootstrap"
+
+description: "Bootstrap all tools and dependencies"
+inputs:
+  go-version:
+    description: "Go version to install"
+    required: true
+    default: "1.21.x"
+  use-go-cache:
+    description: "Restore go cache"
+    required: true
+    default: "true"
+  cache-key-prefix:
+    description: "Prefix all cache keys with this value"
+    required: true
+    default: "831180ac25"
+  build-cache-key-prefix:
+    description: "Prefix build cache key with this value"
+    required: true
+    default: "f8b6d31dea"
+  bootstrap-apt-packages:
+    description: "Space delimited list of tools to install via apt"
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
+      with:
+        go-version: ${{ inputs.go-version }}
+
+    - name: Restore tool cache
+      id: tool-cache
+      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
+      with:
+        path: ${{ github.workspace }}/.tmp
+        key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-tool-${{ hashFiles('Makefile') }}
+
+    # note: we need to keep restoring the go mod cache before bootstrapping tools since `go install` is used in
+    # some installations of project tools.
+    - name: Restore go module cache
+      id: go-mod-cache
+      if: inputs.use-go-cache == 'true'
+      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
+      with:
+        path: |
+          ~/go/pkg/mod
+        key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-go-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-go-${{ inputs.go-version }}-
+
+    - name: (cache-miss) Bootstrap project tools
+      shell: bash
+      if: steps.tool-cache.outputs.cache-hit != 'true'
+      run: make bootstrap-tools
+
+    - name: Restore go build cache
+      id: go-cache
+      if: inputs.use-go-cache == 'true'
+      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
+      with:
+        path: |
+          ~/.cache/go-build
+        key: ${{ inputs.cache-key-prefix }}-${{ inputs.build-cache-key-prefix }}-${{ runner.os }}-go-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ inputs.cache-key-prefix }}-${{ inputs.build-cache-key-prefix }}-${{ runner.os }}-go-${{ inputs.go-version }}-
+
+    - name: (cache-miss) Bootstrap go dependencies
+      shell: bash
+      if: steps.go-mod-cache.outputs.cache-hit != 'true' && inputs.use-go-cache == 'true'
+      run: make bootstrap-go
+
+    - name: Install apt packages
+      if: inputs.bootstrap-apt-packages != ''
+      shell: bash
+      run: |
+        DEBIAN_FRONTEND=noninteractive sudo apt update && sudo -E apt install -y ${{ inputs.bootstrap-apt-packages }}

--- a/.github/scripts/ci-check.sh
+++ b/.github/scripts/ci-check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+red=$(tput setaf 1)
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+# assert we are running in CI (or die!)
+if [[ -z "$CI" ]]; then
+    echo "${bold}${red}This step should ONLY be run in CI. Exiting...${normal}"
+    exit 1
+fi

--- a/.github/scripts/trigger-release.sh
+++ b/.github/scripts/trigger-release.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -eu
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+if ! [ -x "$(command -v gh)" ]; then
+    echo "The GitHub CLI could not be found. To continue follow the instructions at https://github.com/cli/cli#installation"
+    exit 1
+fi
+
+gh auth status
+
+# we need all of the git state to determine the next version. Since tagging is done by
+# the release pipeline it is possible to not have all of the tags from previous releases.
+git fetch --tags
+
+# populates the CHANGELOG.md and VERSION files
+echo "${bold}Generating changelog...${normal}"
+make changelog 2> /dev/null
+
+NEXT_VERSION=$(cat VERSION)
+
+if [[ "$NEXT_VERSION" == "" ||  "${NEXT_VERSION}" == "(Unreleased)" ]]; then
+    echo "Could not determine the next version to release. Exiting..."
+    exit 1
+fi
+
+while true; do
+    read -p "${bold}Do you want to trigger a release for version '${NEXT_VERSION}'?${normal} [y/n] " yn
+    case $yn in
+        [Yy]* ) echo; break;;
+        [Nn]* ) echo; echo "Cancelling release..."; exit;;
+        * ) echo "Please answer yes or no.";;
+    esac
+done
+
+echo "${bold}Kicking off release for ${NEXT_VERSION}${normal}..."
+echo
+gh workflow run release.yaml -f version=${NEXT_VERSION}
+
+echo
+echo "${bold}Waiting for release to start...${normal}"
+sleep 10
+
+set +e
+
+echo "${bold}Head to the release workflow to monitor the release:${normal} $(gh run list --workflow=release.yaml --limit=1 --json url --jq '.[].url')"
+id=$(gh run list --workflow=release.yaml --limit=1 --json databaseId --jq '.[].databaseId')
+gh run watch $id --exit-status || (echo ; echo "${bold}Logs of failed step:${normal}" && GH_PAGER="" gh run view $id --log-failed)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,12 +71,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & publish release artifacts
-        run: make release
+        run: make ci-release
         env:
           # for creating the release (requires write access to packages and content)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: anchore/sbom-action@78fc58e266e87a38d4194b2137a3d4e9bcaf7ca1 #v0.14.3
+        continue-on-error: true
         with:
           artifact-name: sbom.spdx.json
 
@@ -88,4 +89,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
         if: ${{ success() }}
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,29 +1,25 @@
-name: "Release"
-on:
-  push:
-    # take no actions on push to any branch...
-    branches-ignore:
-      - "**"
-    # ... only act on release tags
-    tags:
-      - "v*"
+permissions:
+  contents: read
 
-env:
-  GO_VERSION: "1.21.x"
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: tag the latest commit on main with the given version (prefixed with v)
+        required: true
 
 jobs:
   quality-gate:
     environment: release
-    runs-on: ubuntu-latest # This OS choice is arbitrary. None of the steps in this job are specific to either Linux or macOS.
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
 
-      # we don't want to release commits that have been pushed and tagged, but not necessarily merged onto main
-      - name: Ensure tagged commit is on main
+      - name: Check if tag already exists
+        # note: this will fail if the tag already exists
         run: |
-          echo "Tag: ${GITHUB_REF##*/}"
-          git fetch origin main
-          git merge-base --is-ancestor ${GITHUB_REF##*/} origin/main && echo "${GITHUB_REF##*/} is a commit on main!"
+          [[ "${{ github.event.inputs.version }}" == v* ]] || (echo "version '${{ github.event.inputs.version }}' does not have a 'v' prefix" && exit 1)
+          git tag ${{ github.event.inputs.version }}
 
       - name: Check static analysis results
         uses: fountainhead/action-wait-for-check@297be350cf8393728ea4d4b39435c7d7ae167c93 #v1.1.0
@@ -52,40 +48,32 @@ jobs:
 
   release:
     needs: [quality-gate]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+      contents: write
     steps:
-
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           fetch-depth: 0
 
-      - name: Restore tool cache
-        id: tool-cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
+      - name: Bootstrap environment
+        uses: ./.github/actions/bootstrap
         with:
-          path: ${{ github.workspace }}/.tmp
-          key: ${{ runner.os }}-tool-${{ hashFiles('Makefile') }}
+          # use the same cache we used for building snapshots
+          build-cache-key-prefix: "snapshot"
 
-      - name: Restore go cache
-        id: go-cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ env.GO_VERSION }}-
-
-      - name: (cache-miss) Bootstrap all project dependencies
-        if: steps.tool-cache.outputs.cache-hit != 'true' || steps.go-cache.outputs.cache-hit != 'true'
-        run: make bootstrap
+      - name: Tag release
+        run: |
+          git tag -a ${{ github.event.inputs.version }} -m "Release ${{ github.event.inputs.version }}"
+          git push origin --tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & publish release artifacts
         run: make release
         env:
+          # for creating the release (requires write access to packages and content)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: anchore/sbom-action@78fc58e266e87a38d4194b2137a3d4e9bcaf7ca1 #v0.14.3
@@ -96,12 +84,8 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: repo,workflow,action,eventName
-          text: "A new Chronicle release is ready to be manually published: https://github.com/anchore/chronicle/releases"
+          text: "A new Chronicle release has been published: https://github.com/anchore/chronicle/releases"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
         if: ${{ success() }}
 
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 #v3.1.3
-        with:
-          name: artifacts
-          path: dist/**/*

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -1,49 +1,22 @@
 name: "Validations"
 on:
+  merge_group:
   workflow_dispatch:
   pull_request:
   push:
     branches:
       - main
 
-env:
-  GO_VERSION: "1.21.x"
-
 jobs:
-
   Static-Analysis:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Static analysis"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
 
-      - name: Restore tool cache
-        id: tool-cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
-        with:
-          path: ${{ github.workspace }}/.tmp
-          key: ${{ runner.os }}-tool-${{ hashFiles('Makefile') }}
-
-      - name: Restore go cache
-        id: go-cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ env.GO_VERSION }}-
-
-      - name: (cache-miss) Bootstrap all project dependencies
-        if: steps.tool-cache.outputs.cache-hit != 'true' || steps.go-cache.outputs.cache-hit != 'true'
-        run: make bootstrap
-
-      - name: Bootstrap CI environment dependencies
-        run: make ci-bootstrap
+      - name: Bootstrap environment
+        uses: ./.github/actions/bootstrap
 
       - name: Run static analysis
         run: make static-analysis
@@ -51,38 +24,15 @@ jobs:
   Unit-Test:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Unit tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
 
-      - name: Restore tool cache
-        id: tool-cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
-        with:
-          path: ${{ github.workspace }}/.tmp
-          key: ${{ runner.os }}-tool-${{ hashFiles('Makefile') }}
+      - name: Bootstrap environment
+        uses: ./.github/actions/bootstrap
 
-      - name: Restore go cache
-        id: go-cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ env.GO_VERSION }}-
 
-      - name: (cache-miss) Bootstrap all project dependencies
-        if: steps.tool-cache.outputs.cache-hit != 'true' || steps.go-cache.outputs.cache-hit != 'true'
-        run: make bootstrap
-
-      - name: Bootstrap CI environment dependencies
-        run: make ci-bootstrap
-
-      - name: Build cache key for test-fixturew
+      - name: Build cache key for test-fixture
         run: make fixtures-fingerprint
 
       - name: Restore test-fixture cache
@@ -95,45 +45,21 @@ jobs:
       - name: Run unit tests
         run: make unit
 
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 #3.1.3
-        with:
-          name: unit-test-results
-          path: test/results/**/*
-
   Build-Snapshot-Artifacts:
     name: "Build snapshot artifacts"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
 
-      - name: Restore tool cache
-        id: tool-cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
+      - name: Bootstrap environment
+        uses: ./.github/actions/bootstrap
         with:
-          path: ${{ github.workspace }}/.tmp
-          key: ${{ runner.os }}-tool-${{ hashFiles('Makefile') }}
-
-      - name: Restore go cache
-        id: go-cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ env.GO_VERSION }}-
-
-      - name: (cache-miss) Bootstrap all project dependencies
-        if: steps.tool-cache.outputs.cache-hit != 'true' || steps.go-cache.outputs.cache-hit != 'true'
-        run: make bootstrap
+          # why have another build cache key? We don't want unit/integration/etc test build caches to replace
+          # the snapshot build cache, which includes builds for all OSs and architectures. As long as this key is
+          # unique from the build-cache-key-prefix in other CI jobs, we should be fine.
+          #
+          # note: ideally this value should match what is used in release (just to help with build times).
+          build-cache-key-prefix: "snapshot"
 
       - name: Build snapshot artifacts
         run: make snapshot
-
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 #v3.1.3
-        with:
-          name: artifacts
-          path: snapshot/**/*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,10 +1,8 @@
 release:
   # If set to auto, will mark the release as not ready for production in case there is an indicator for this in the
-  # tag e.g. v1.0.0-rc1 .If set to true, will mark the release as not ready for production.
+  # tag (e.g. v1.0.0-rc1). If set to true, will mark the release as not ready for production.
   prerelease: auto
-
-  # If set to true, will not auto-publish the release. This is done to allow us to review the changelog before publishing.
-  draft: true
+  draft: false
 
 builds:
   - id: chronicle

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,31 @@
+# Release
+
+## Creating a release
+
+This release process itself should be as automated as possible, and has only a few steps:
+
+1. **Trigger a new release with `make release`**. At this point you'll see a preview
+   changelog in the terminal. If you're happy with the changelog, press `y` to continue, otherwise
+   you can abort and adjust the labels on the PRs and issues to be included in the release and
+   re-run the release trigger command.
+
+1. A release admin must approve the release on the GitHub Actions release pipeline run page.
+   Once approved, the release pipeline will generate all assets and publish a GitHub Release.
+
+1. If there is a release Milestone, close it.
+
+Ideally releasing should be done often with small increments when possible. Unless a
+breaking change is blocking the release, or no fixes/features have been merged, a good
+target release cadence is between every 1 or 2 weeks.
+
+
+## Retracting a release
+
+If a release is found to be problematic, it can be retracted with the following steps:
+
+- Delete the GitHub Release
+- Add a new `retract` entry in the go.mod for the versioned release
+
+**Note**: do not delete release tags from the git repository since there may already be references to the release
+in the go proxy, which will cause confusion when trying to reuse the tag later (the H1 hash will not match and there
+will be a warning when users try to pull the new release).


### PR DESCRIPTION
This brings the latest CI patterns from syft into this repo, specifically:
- use a single bootstrap action and reuse in multiple jobs
- add `make release` target to trigger tagging to be done in the workflow (not locally)
- restricts GITHUB_TOKEN permissions to read only by default
- upgrades job runners to ubuntu 22.04
- replaces draft-only goreleaser config with direct-to-publish release workflow

This makes additional pattern changes:
- swaps to using annotated tags instead of lightweight tags
- swaps the chronicle version used in the pipeline to the current branch