### PR TITLE
Bump shared workflow to main branch

### DIFF
--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -7,4 +7,4 @@ permissions:
 
 jobs:
   run:
-    uses: anchore/workflows/.github/workflows/dependabot-automation.yaml@dependabot-auto-approve
+    uses: anchore/workflows/.github/workflows/dependabot-automation.yaml@main


### PR DESCRIPTION
Now that the shared workflow for auto approving dependabot PRs has been checked, this bumps from the feature branch to the main branch.