### PR TITLE
feat: update to go 1.24.x

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -5,7 +5,7 @@ inputs:
   go-version:
     description: "Go version to install"
     required: true
-    default: "1.21.x"
+    default: "1.24.x"
   use-go-cache:
     description: "Restore go cache"
     required: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,7 +18,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
+    - copyloopvar
     - funlen
     - gocognit
     - goconst

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CHRONICLE_CMD = $(TEMP_DIR)/chronicle
 GLOW_CMD = $(TEMP_DIR)/glow
 
 # Tool versions #################################
-GOLANG_CI_VERSION = v1.54.2
+GOLANG_CI_VERSION = v1.64.2
 GOBOUNCER_VERSION = v0.4.0
 GORELEASER_VERSION = v1.17.0
 GOSIMPORTS_VERSION = v0.3.8
@@ -101,7 +101,6 @@ $(TEMP_DIR):
 
 .PHONY: bootstrap-tools
 bootstrap-tools: $(TEMP_DIR)
-	GO111MODULE=off GOBIN=$(realpath $(TEMP_DIR)) go get -u golang.org/x/perf/cmd/benchstat
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMP_DIR)/ $(GOLANG_CI_VERSION)
 	curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMP_DIR)/ $(GOBOUNCER_VERSION)
 	# we purposefully use the latest version of chronicle released

--- a/cmd/chronicle/cli/commands/next_version.go
+++ b/cmd/chronicle/cli/commands/next_version.go
@@ -40,7 +40,7 @@ func NextVersion(app clio.Application) *cobra.Command {
 			cfg.RepoPath = repo
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runNextVersion(cfg)
 		},
 	}, cfg)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/anchore/chronicle
 
-go 1.21.1
-toolchain go1.22.5
+go 1.24.0
 
 require (
 	github.com/anchore/clio v0.0.0-20230802135737-4778c80552e5


### PR DESCRIPTION
Update to building with go [1.24.x](https://tip.golang.org/doc/go1.24) so that the main module version gets set during go build