### PR TITLE
chore: update codeql permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,9 @@ on:
   schedule:
     - cron: '0 0 * * 3'
 
+permissions:
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
This PR updates the CodeQL permissions to be able to upload a security report without failures such as: https://github.com/anchore/chronicle/actions/runs/15168423589/job/42652175541#step:6:293