### PR TITLE
chore(ci): better zizmor

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,6 +11,8 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -19,3 +21,5 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,13 +92,24 @@ jobs:
         with:
           artifact-name: sbom.spdx.json
 
-      - uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e #v3.19.0
+      - name: Notify Slack of new release
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a #v2.1.1
+        continue-on-error: true
         with:
-          status: ${{ job.status }}
-          fields: repo,workflow,action,eventName
-          text: "A new Chronicle release has been published: https://github.com/anchore/chronicle/releases"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "A new Chronicle release has been published: https://github.com/anchore/chronicle/releases/tag/${{ github.event.inputs.version }}"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: |
+                    *A new Chronicle release has been published* :rocket:
+                    • Release: <https://github.com/anchore/chronicle/releases/tag/${{ github.event.inputs.version }}|${{ github.event.inputs.version }}>
+                    • Repo: `${{ github.repository }}`
+                    • Workflow: `${{ github.workflow }}`
+                    • Event: `${{ github.event_name }}`
         if: ${{ success() }}
 
   release-install-script:

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -21,7 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: write  # for uploading SARIF results
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -30,6 +29,7 @@ jobs:
       - name: "Run zizmor"
         uses: zizmorcore/zizmor-action@135698455da5c3b3e55f73f4419e481ab68cdd95 # v0.4.1
         with:
-          config-file: .github/zizmor.yml
-          sarif-upload: true
+          config: .github/zizmor.yml
+          # disabled sarif uploading to make the action be a simple pass/fail gate
+          sarif-upload: false
           inputs: .github

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # anchore/workflows is an internal repository; using @main is acceptable
+        anchore/*: any


### PR DESCRIPTION
Configure zizmor to be a pass/fail lint instead of uploading sarif events, and fix anything that has snuck in.