### PR TITLE
require zizmor security events

### DIFF
--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -21,15 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write  # for uploading SARIF results
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: "Run zizmor"
-        uses: zizmorcore/zizmor-action@135698455da5c3b3e55f73f4419e481ab68cdd95 # v0.4.1
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:
-          config: .github/zizmor.yml
-          # disabled sarif uploading to make the action be a simple pass/fail gate
-          advanced-security: false
+          # there is a pass/fail gate as a repo ruleset (if there is no ruleset configured then the action will pass by default)
+          advanced-security: true
           inputs: .github


### PR DESCRIPTION
enables writing zizmor security events to enforce rulesets