### PR TITLE
Provide version/changelog even when there are no existing tags or releases

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -2,7 +2,7 @@ tools:
   # we want to use a pinned version of binny to manage the toolchain (so binny manages itself!)
   - name: binny
     version:
-      want: v0.9.0
+      want: v0.13.0
     method: github-release
     with:
       repo: anchore/binny
@@ -18,7 +18,7 @@ tools:
   # used for signing the checksums file at release
   - name: cosign
     version:
-      want: v2.4.1
+      want: v3.0.5
     method: github-release
     with:
       repo: sigstore/cosign
@@ -26,7 +26,7 @@ tools:
   # used to sign mac binaries at release
   - name: quill
     version:
-      want: v0.4.2
+      want: v0.7.1
     method: github-release
     with:
       repo: anchore/quill
@@ -34,7 +34,7 @@ tools:
   # used for linting
   - name: golangci-lint
     version:
-      want: v2.3.0
+      want: v2.11.4
     method: github-release
     with:
       repo: golangci/golangci-lint
@@ -42,7 +42,7 @@ tools:
   # used for showing the changelog at release
   - name: glow
     version:
-      want: v2.0.0
+      want: v2.1.1
     method: github-release
     with:
       repo: charmbracelet/glow
@@ -50,7 +50,7 @@ tools:
   # used to release all artifacts
   - name: goreleaser
     version:
-      want: v2.3.2
+      want: v2.15.2
     method: github-release
     with:
       repo: goreleaser/goreleaser
@@ -82,7 +82,7 @@ tools:
   # used for running all local and CI tasks
   - name: task
     version:
-      want: v3.39.2
+      want: v3.49.1
     method: github-release
     with:
       repo: go-task/task
@@ -90,7 +90,7 @@ tools:
   # used for triggering a release
   - name: gh
     version:
-      want: v2.58.0
+      want: v2.89.0
     method: github-release
     with:
       repo: cli/cli

--- a/chronicle/release/changelog_info.go
+++ b/chronicle/release/changelog_info.go
@@ -28,13 +28,15 @@ func ChangelogInfo(summer Summarizer, config ChangelogInfoConfig) (*Release, *De
 		return nil, nil, err
 	}
 
+	var startReleaseVersion string
 	if startRelease != nil {
 		log.WithFields("tag", startRelease.Version, "release-timestamp", internal.FormatDateTime(startRelease.Date)).Trace("since")
+		startReleaseVersion = startRelease.Version
 	} else {
 		log.Trace("since the beginning of git history")
 	}
 
-	releaseVersion, changes, err := changelogChanges(startRelease.Version, summer, config)
+	releaseVersion, changes, err := changelogChanges(startReleaseVersion, summer, config)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -52,7 +54,7 @@ func ChangelogInfo(summer Summarizer, config ChangelogInfoConfig) (*Release, *De
 			Date:    time.Now(),
 		},
 		VCSReferenceURL:  summer.ReferenceURL(releaseVersion),
-		VCSChangesURL:    summer.ChangesURL(startRelease.Version, releaseVersion),
+		VCSChangesURL:    summer.ChangesURL(startReleaseVersion, releaseVersion),
 		Changes:          changes,
 		SupportedChanges: config.ChangeTypeTitles,
 		Notice:           "", // TODO...
@@ -114,9 +116,11 @@ func getChangelogStartingRelease(summer Summarizer, sinceTag string) (*Release, 
 		lastRelease, err = summer.LastRelease()
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine last release: %w", err)
-		} else if lastRelease == nil {
-			// TODO: support when there hasn't been the first release (use date of first repo commit)
-			return nil, errors.New("unable to determine last release")
+		}
+		if lastRelease == nil {
+			// no prior release found, signal "since the beginning of time"
+			log.Debug("no prior release found, using beginning of git history")
+			return nil, nil
 		}
 	}
 	return lastRelease, nil

--- a/chronicle/release/changelog_info_test.go
+++ b/chronicle/release/changelog_info_test.go
@@ -26,12 +26,12 @@ func Test_getChangelogStartingRelease(t *testing.T) {
 			},
 		},
 		{
-			name:     "error when fallback to last release does not exist",
+			name:     "nil release when fallback to last release does not exist",
 			sinceTag: "",
 			summer: MockSummarizer{
 				MockLastRelease: "",
 			},
-			wantErr: require.Error,
+			want: nil,
 		},
 		{
 			name:     "use given release (which exists)",
@@ -60,6 +60,32 @@ func Test_getChangelogStartingRelease(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestChangelogInfo_NoRelease(t *testing.T) {
+	// test that ChangelogInfo handles the case when no prior release exists
+	summer := MockSummarizer{
+		MockLastRelease: "",
+		MockChangesURL:  "https://github.com/owner/repo/commits/v0.1.0",
+		MockRefURL:      "https://github.com/owner/repo/tree/v0.1.0",
+	}
+	config := ChangelogInfoConfig{
+		VersionSpeculator: MockVersionSpeculator{
+			MockNextIdealVersion:  "v0.1.0",
+			MockNextUniqueVersion: "v0.1.0",
+		},
+	}
+
+	startRelease, description, err := ChangelogInfo(summer, config)
+	require.NoError(t, err)
+
+	// startRelease should be nil when no prior release exists
+	assert.Nil(t, startRelease)
+
+	// description should still be generated
+	require.NotNil(t, description)
+	assert.Equal(t, "v0.1.0", description.Release.Version)
+	assert.Equal(t, "https://github.com/owner/repo/commits/v0.1.0", description.VCSChangesURL)
 }
 
 func Test_changelogChanges(t *testing.T) {

--- a/chronicle/release/releasers/github/summarizer.go
+++ b/chronicle/release/releasers/github/summarizer.go
@@ -100,6 +100,10 @@ func (s *Summarizer) ReferenceURL(ref string) string {
 }
 
 func (s *Summarizer) ChangesURL(sinceRef, untilRef string) string {
+	if sinceRef == "" {
+		// no prior release, return commits page instead of invalid compare URL
+		return fmt.Sprintf("https://%s/%s/%s/commits/%s", s.config.Host, s.userName, s.repoName, untilRef)
+	}
 	return fmt.Sprintf("https://%s/%s/%s/compare/%s...%s", s.config.Host, s.userName, s.repoName, sinceRef, untilRef)
 }
 
@@ -115,7 +119,8 @@ func (s *Summarizer) LastRelease() (*release.Release, error) {
 			Date:    latestRelease.Date,
 		}, nil
 	}
-	return nil, fmt.Errorf("unable to find latest release")
+	// no releases found, return nil to signal "since the beginning"
+	return nil, nil
 }
 
 func (s *Summarizer) Changes(sinceRef, untilRef string) ([]change.Change, error) {
@@ -312,10 +317,13 @@ func logCommits(commits []string) {
 func issuesExtractedFromPRs(config Config, allMergedPRs []ghPullRequest, sinceTag, untilTag *git.Tag, includeCommits []string) []ghIssue {
 	// this represents the traits we wish to filter down to (not out).
 	prFilters := []prFilter{
-		prsAfter(sinceTag.Timestamp.UTC()),
 		// PRs with these labels should explicitly be used in the changelog directly (not the corresponding linked issue)
 		prsWithoutLabel(config.ChangeTypesByLabel.Names()...),
 		prsWithClosedLinkedIssue(),
+	}
+
+	if sinceTag != nil {
+		prFilters = append([]prFilter{prsAfter(sinceTag.Timestamp.UTC())}, prFilters...)
 	}
 
 	if untilTag != nil {
@@ -327,9 +335,12 @@ func issuesExtractedFromPRs(config Config, allMergedPRs []ghPullRequest, sinceTa
 
 	// this represents the traits we wish to filter down to (not out).
 	issueFilters := []issueFilter{
-		issuesAfter(sinceTag.Timestamp),
 		issuesWithLabel(config.ChangeTypesByLabel.Names()...),
 		issuesWithoutLabel(config.ExcludeLabels...),
+	}
+
+	if sinceTag != nil {
+		issueFilters = append([]issueFilter{issuesAfter(sinceTag.Timestamp)}, issueFilters...)
 	}
 
 	if untilTag != nil {

--- a/chronicle/release/releasers/github/summarizer_test.go
+++ b/chronicle/release/releasers/github/summarizer_test.go
@@ -1396,6 +1396,43 @@ func gitFirstCommit(t *testing.T, path string) string {
 	return rows[0]
 }
 
+func TestSummarizer_ChangesURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		sinceRef string
+		untilRef string
+		want     string
+	}{
+		{
+			name:     "normal compare URL",
+			sinceRef: "v0.1.0",
+			untilRef: "v0.2.0",
+			want:     "https://github.com/owner/repo/compare/v0.1.0...v0.2.0",
+		},
+		{
+			name:     "empty sinceRef returns commits URL",
+			sinceRef: "",
+			untilRef: "v0.2.0",
+			want:     "https://github.com/owner/repo/commits/v0.2.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Summarizer{
+				userName: "owner",
+				repoName: "repo",
+				config: Config{
+					Host: "github.com",
+				},
+			}
+
+			got := s.ChangesURL(tt.sinceRef, tt.untilRef)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func gitLogRange(t *testing.T, path, since, until string, startInclusive bool) []string {
 	t.Helper()
 

--- a/chronicle/release/releasers/github/testdata/create-v0.1.0-dev-repo.sh
+++ b/chronicle/release/releasers/github/testdata/create-v0.1.0-dev-repo.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eux -o pipefail
 
+# ignore global and system git config to prevent interference from the host
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
 if [ -d "/path/to/dir" ]
 then
     echo "fixture already exists!"
@@ -15,6 +19,7 @@ pushd repos/v0.1.0-dev-repo
 
 git config --local user.email "nope@nope.com"
 git config --local user.name "nope"
+git config --local commit.gpgsign false
 
 git remote add origin git@github.com:wagoodman/count-goober.git
 

--- a/chronicle/release/releasers/github/testdata/create-v0.2.0-repo.sh
+++ b/chronicle/release/releasers/github/testdata/create-v0.2.0-repo.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eux -o pipefail
 
+# ignore global and system git config to prevent interference from the host
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
 if [ -d "/path/to/dir" ]
 then
     echo "fixture already exists!"
@@ -15,6 +19,7 @@ pushd repos/v0.2.0-repo
 
 git config --local user.email "nope@nope.com"
 git config --local user.name "nope"
+git config --local commit.gpgsign false
 
 git remote add origin git@github.com:wagoodman/count-goober.git
 

--- a/chronicle/release/releasers/github/testdata/create-v0.3.0-dev-repo.sh
+++ b/chronicle/release/releasers/github/testdata/create-v0.3.0-dev-repo.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eux -o pipefail
 
+# ignore global and system git config to prevent interference from the host
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
 if [ -d "/path/to/dir" ]
 then
     echo "fixture already exists!"
@@ -15,6 +19,7 @@ pushd repos/v0.3.0-dev-repo
 
 git config --local user.email "nope@nope.com"
 git config --local user.name "nope"
+git config --local commit.gpgsign false
 
 git remote add origin git@github.com:wagoodman/count-goober.git
 

--- a/chronicle/release/releasers/github/version_speculator.go
+++ b/chronicle/release/releasers/github/version_speculator.go
@@ -44,6 +44,11 @@ func (s VersionSpeculator) NextIdealVersion(currentVersion string, changes chang
 		}
 	}
 
+	// when there's no prior release, default to v0.0.0 as the starting point
+	if currentVersion == "" {
+		currentVersion = "v0.0.0"
+	}
+
 	v, err := semver.NewVersion(strings.TrimLeft(currentVersion, "v"))
 	if err != nil {
 		return "", fmt.Errorf("invalid current version given: %q: %w", currentVersion, err)

--- a/chronicle/release/releasers/github/version_speculator_test.go
+++ b/chronicle/release/releasers/github/version_speculator_test.go
@@ -132,6 +132,37 @@ func TestFindNextVersion(t *testing.T) {
 			release: "a10",
 			wantErr: require.Error,
 		},
+		{
+			name:    "empty version with minor change",
+			release: "",
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{minorChange},
+				},
+			},
+			want: "v0.1.0",
+		},
+		{
+			name:    "empty version with patch change",
+			release: "",
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{patchChange},
+				},
+			},
+			want: "v0.0.1",
+		},
+		{
+			name:                "empty version with no changes -- bump patch",
+			release:             "",
+			bumpPatchOnNoChange: true,
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{},
+				},
+			},
+			want: "v0.0.1",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/git/testdata/create-annotated-tagged-repo.sh
+++ b/internal/git/testdata/create-annotated-tagged-repo.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eux -o pipefail
 
+# ignore global and system git config to prevent interference from the host
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
 if [ -d "/path/to/dir" ]
 then
     echo "fixture already exists!"
@@ -15,6 +19,7 @@ pushd repos/annotated-tagged-repo
 
 git config --local user.email "nope@nope.com"
 git config --local user.name "nope"
+git config --local commit.gpgsign false
 
 trap 'popd' EXIT
 

--- a/internal/git/testdata/create-commit-in-repo.sh
+++ b/internal/git/testdata/create-commit-in-repo.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eux -o pipefail
 
+# ignore global and system git config to prevent interference from the host
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
 if [ -d "/path/to/dir" ]
 then
     echo "fixture already exists!"
@@ -15,6 +19,7 @@ pushd repos/commit-in-repo
 
 git config --local user.email "nope@nope.com"
 git config --local user.name "nope"
+git config --local commit.gpgsign false
 
 trap 'popd' EXIT
 

--- a/internal/git/testdata/create-remote-repo.sh
+++ b/internal/git/testdata/create-remote-repo.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eux -o pipefail
 
+# ignore global and system git config to prevent interference from the host
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
 if [ -d "/path/to/dir" ]
 then
     echo "fixture already exists!"
@@ -15,6 +19,7 @@ pushd repos/remote-repo
 
 git config --local user.email "nope@nope.com"
 git config --local user.name "nope"
+git config --local commit.gpgsign false
 
 trap 'popd' EXIT
 

--- a/internal/git/testdata/create-tag-range-repo.sh
+++ b/internal/git/testdata/create-tag-range-repo.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eux -o pipefail
 
+# ignore global and system git config to prevent interference from the host
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
 if [ -d "/path/to/dir" ]
 then
     echo "fixture already exists!"
@@ -15,6 +19,7 @@ pushd repos/tag-range-repo
 
 git config --local user.email "nope@nope.com"
 git config --local user.name "nope"
+git config --local commit.gpgsign false
 
 trap 'popd' EXIT
 

--- a/internal/git/testdata/create-tagged-repo.sh
+++ b/internal/git/testdata/create-tagged-repo.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eux -o pipefail
 
+# ignore global and system git config to prevent interference from the host
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
 if [ -d "/path/to/dir" ]
 then
     echo "fixture already exists!"
@@ -15,6 +19,7 @@ pushd repos/tagged-repo
 
 git config --local user.email "nope@nope.com"
 git config --local user.name "nope"
+git config --local commit.gpgsign false
 
 trap 'popd' EXIT
 


### PR DESCRIPTION
Today if a new-ish repo with no tags or releases runs chronicle (typical just before the first release) then chronicle will exit 1 with no message. This PR addresses this by providing the first version according to the kind of change.

This also updates the test fixtures to ignore global/system git configurations (I wasn't able to get tests passing without this).