### PR TITLE
Remove fixtures build during release

### DIFF
--- a/.make/go.mod
+++ b/.make/go.mod
@@ -2,7 +2,7 @@ module github.com/anchore/chronicle/.make
 
 go 1.25.0
 
-require github.com/anchore/go-make v0.0.3-0.20260402185526-1b44efca6ec3
+require github.com/anchore/go-make v0.0.3-0.20260404141443-d617d98ba14f
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect

--- a/.make/go.sum
+++ b/.make/go.sum
@@ -1,5 +1,7 @@
 github.com/anchore/go-make v0.0.3-0.20260402185526-1b44efca6ec3 h1:Gdtl5WU0kyNWVH8fNAv5Ens7ctqksHf+OQV/bF3bSvA=
 github.com/anchore/go-make v0.0.3-0.20260402185526-1b44efca6ec3/go.mod h1:JafD2Md95wih7aGmA12yVoReZW3mOgIuwHbw5aOcIOQ=
+github.com/anchore/go-make v0.0.3-0.20260404141443-d617d98ba14f h1:nxephbdNbJVH+TZg9wz/BChmqtTCbBzucHjtXS+VnME=
+github.com/anchore/go-make v0.0.3-0.20260404141443-d617d98ba14f/go.mod h1:JafD2Md95wih7aGmA12yVoReZW3mOgIuwHbw5aOcIOQ=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=

--- a/.make/main.go
+++ b/.make/main.go
@@ -14,6 +14,6 @@ func main() {
 		release.ChangelogTask(),
 		goreleaser.Tasks(),
 		gotest.Tasks(),
-		gotest.FixtureTasks().RunOn("ci-release"),
+		gotest.FixtureTasks().RunOn("unit"),
 	)
 }


### PR DESCRIPTION
This removes the fixtures from being built during release, instead running on unit tests. Additionally this pulls in the latest `go-make` tasks to fix changelog generation.