### PR TITLE
Add more information from logs and errors

### DIFF
--- a/.chronicle.yaml
+++ b/.chronicle.yaml
@@ -1,4 +1,1 @@
-log:
-  level: trace
-
 title: ''

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ VERSION
 /snapshot
 /.tool
 /.task
+/specs
+/docs
+/doc
 
 # changelog generation
 CHANGELOG.md

--- a/chronicle/release/changelog_info.go
+++ b/chronicle/release/changelog_info.go
@@ -4,9 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
-
-	"github.com/scylladb/go-set/strset"
 
 	"github.com/anchore/chronicle/chronicle/release/change"
 	"github.com/anchore/chronicle/internal"
@@ -30,10 +29,10 @@ func ChangelogInfo(summer Summarizer, config ChangelogInfoConfig) (*Release, *De
 
 	var startReleaseVersion string
 	if startRelease != nil {
-		log.WithFields("tag", startRelease.Version, "release-timestamp", internal.FormatDateTime(startRelease.Date)).Trace("since")
+		log.WithFields("tag", startRelease.Version, "release-timestamp", internal.FormatDateTime(startRelease.Date)).Info("since")
 		startReleaseVersion = startRelease.Version
 	} else {
-		log.Trace("since the beginning of git history")
+		log.Info("since the beginning of git history")
 	}
 
 	releaseVersion, changes, err := changelogChanges(startReleaseVersion, summer, config)
@@ -98,7 +97,7 @@ func speculateNextVersion(speculator VersionSpeculator, startReleaseVersion stri
 	if nextUniqueVersion != nextIdealVersion {
 		log.Debugf("speculated a release version that matches an existing tag=%q, selecting the next best version...", nextIdealVersion)
 	}
-	log.WithFields("version", nextUniqueVersion).Info("speculative release version")
+	log.WithFields("version", nextUniqueVersion).Info("🔮 speculative release version")
 	return nextUniqueVersion, nil
 }
 
@@ -119,7 +118,7 @@ func getChangelogStartingRelease(summer Summarizer, sinceTag string) (*Release, 
 		}
 		if lastRelease == nil {
 			// no prior release found, signal "since the beginning of time"
-			log.Debug("no prior release found, using beginning of git history")
+			log.Info("no prior GitHub release found; producing changelog from the beginning of git history")
 			return nil, nil
 		}
 	}
@@ -127,36 +126,70 @@ func getChangelogStartingRelease(summer Summarizer, sinceTag string) (*Release, 
 }
 
 func logChanges(changes change.Changes) {
-	log.Infof("discovered changes: %d", len(changes))
-
-	set := strset.New()
-	count := make(map[string]int)
+	byType := make(map[string][]change.Change)
 	lookup := make(map[string]change.Type)
 	for _, c := range changes {
 		for _, ty := range c.ChangeTypes {
-			_, exists := count[ty.Name]
-			if !exists {
-				count[ty.Name] = 0
-			}
-			count[ty.Name]++
-			set.Add(ty.Name)
+			byType[ty.Name] = append(byType[ty.Name], c)
 			lookup[ty.Name] = ty
 		}
 	}
 
-	typeNames := set.List()
+	typeNames := make([]string, 0, len(byType))
+	for name := range byType {
+		typeNames = append(typeNames, name)
+	}
 	sort.Strings(typeNames)
 
-	for idx, tyName := range typeNames {
-		var branch = "├──"
-		if idx == len(typeNames)-1 {
-			branch = "└──"
+	// INFO rollup: total + a flat field per change type so structured loggers see each as its
+	// own key (rather than a pre-folded "by-type=…" string).
+	fields := []interface{}{"count", len(changes)}
+	for _, tyName := range typeNames {
+		t := lookup[tyName]
+		var val string
+		if t.Kind != change.SemVerUnknown {
+			val = fmt.Sprintf("%d (%s)", len(byType[tyName]), t.Kind)
+		} else {
+			val = fmt.Sprintf("%d", len(byType[tyName]))
+		}
+		fields = append(fields, tyName, val)
+	}
+	log.WithFields(fields...).Info("📝 discovered changes")
+
+	// DEBUG evidence tree: which changes fell into which type
+	for tIdx, tyName := range typeNames {
+		typeBranch := "├──"
+		entryIndent := "│   "
+		if tIdx == len(typeNames)-1 {
+			typeBranch = "└──"
+			entryIndent = "    "
 		}
 		t := lookup[tyName]
 		if t.Kind != change.SemVerUnknown {
-			log.Debugf("  %s %s (%s bump): %d", branch, tyName, t.Kind, count[tyName])
+			log.Debugf("  %s %s (%d, %s bump)", typeBranch, tyName, len(byType[tyName]), t.Kind)
 		} else {
-			log.Debugf("  %s %s: %d", branch, tyName, count[tyName])
+			log.Debugf("  %s %s (%d)", typeBranch, tyName, len(byType[tyName]))
+		}
+		entries := byType[tyName]
+		for eIdx, c := range entries {
+			leaf := "├──"
+			if eIdx == len(entries)-1 {
+				leaf = "└──"
+			}
+			log.Debugf("  %s%s %s %s", entryIndent, leaf, primaryRef(c), c.Text)
 		}
 	}
+}
+
+// primaryRef returns the most identifying reference for a change (e.g. "#19"), or "" if none.
+func primaryRef(c change.Change) string {
+	for _, r := range c.References {
+		if strings.HasPrefix(r.Text, "#") {
+			return r.Text
+		}
+	}
+	if len(c.References) > 0 {
+		return c.References[0].Text
+	}
+	return ""
 }

--- a/chronicle/release/releasers/github/api_errors.go
+++ b/chronicle/release/releasers/github/api_errors.go
@@ -1,0 +1,30 @@
+package github
+
+import (
+	"fmt"
+	"strings"
+)
+
+// explainGithubAPIError adds an actionable hint for common GitHub API failure modes.
+// The shurcooL/githubv4 client returns errors like:
+//
+//	non-200 OK status code: 401 Unauthorized body: "..."
+//	non-200 OK status code: 403 Forbidden body: "..."
+//	non-200 OK status code: 404 Not Found body: "..."
+//
+// here we sniff the message text (the client doesn't expose a structured status code) and prepend a hint.
+func explainGithubAPIError(operation string, user, repo string, err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "401"):
+		return fmt.Errorf("%s: GitHub authentication failed (HTTP 401). Set GITHUB_TOKEN to a token with 'repo' scope (or 'public_repo' for public repositories): %w", operation, err)
+	case strings.Contains(msg, "403"):
+		return fmt.Errorf("%s: GitHub authorization failed (HTTP 403). The token may lack required scopes, or you've hit the API rate limit: %w", operation, err)
+	case strings.Contains(msg, "404"):
+		return fmt.Errorf("%s: GitHub repository %q not found (HTTP 404). Check spelling and that the token can access it: %w", operation, user+"/"+repo, err)
+	}
+	return fmt.Errorf("%s: %w", operation, err)
+}

--- a/chronicle/release/releasers/github/find_changelog_end_tag.go
+++ b/chronicle/release/releasers/github/find_changelog_end_tag.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/anchore/chronicle/chronicle/release"
 	"github.com/anchore/chronicle/internal/git"
@@ -12,24 +13,39 @@ func FindChangelogEndTag(summer release.Summarizer, gitter git.Interface) (strin
 	// check if the current commit is tagged, then use that
 	currentTag, err := gitter.HeadTag()
 	if err != nil {
-		return "", fmt.Errorf("problem while attempting to find head tag: %w", err)
+		return "", fmt.Errorf("problem while attempting to find HEAD tag: %w", err)
 	}
 	if currentTag == "" {
 		return "", nil
 	}
 
-	if taggedRelease, err := summer.Release(currentTag); err != nil {
-		// TODO: assert the error specifically confirms that the release does not exist, not just any error
-		// no release found, assume that this is the correct release info
-		return "", fmt.Errorf("unable to fetch release=%q : %w", currentTag, err)
-	} else if taggedRelease != nil {
-		log.WithFields("tag", currentTag).Debug("found existing tag however, it already has an associated release. ignoring...")
-		// return commitRef, nil
+	taggedRelease, err := summer.Release(currentTag)
+	if err != nil {
+		// the GitHub GraphQL API returns this message body when the release for a given tag does not exist;
+		// only treat that specific case as "no release yet" and propagate everything else.
+		if isReleaseNotFoundErr(err) {
+			log.WithFields("tag", currentTag).Debug("no GitHub release exists for HEAD tag yet")
+			return currentTag, nil
+		}
+		return "", fmt.Errorf("unable to fetch release for tag %q: %w", currentTag, err)
+	}
+	if taggedRelease != nil {
+		log.WithFields("tag", currentTag).Info("HEAD tag already has an associated GitHub release; ignoring")
 		return "", nil
 	}
 
-	log.WithFields("tag", currentTag).Debug("found existing tag at HEAD which does not have an associated release")
+	log.WithFields("tag", currentTag).Info("found tag at HEAD without an associated GitHub release")
 
 	// a tag was found and there is no existing release for this tag
 	return currentTag, nil
+}
+
+func isReleaseNotFoundErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	// known GitHub GraphQL responses for missing release lookups
+	return strings.Contains(msg, "Could not resolve to a Release") ||
+		strings.Contains(msg, "Could not resolve to a node with the global id")
 }

--- a/chronicle/release/releasers/github/gh_issue.go
+++ b/chronicle/release/releasers/github/gh_issue.go
@@ -229,7 +229,7 @@ func fetchClosedIssues(user, repo string, since *time.Time) ([]ghIssue, error) {
 
 			err := client.Query(context.Background(), &query, variables)
 			if err != nil {
-				return nil, err
+				return nil, explainGithubAPIError("query GitHub closed issues", user, repo, err)
 			}
 
 			// limit = query.RateLimit

--- a/chronicle/release/releasers/github/gh_pull_request.go
+++ b/chronicle/release/releasers/github/gh_pull_request.go
@@ -29,18 +29,25 @@ type prFilter func(issue ghPullRequest) bool
 
 func applyPRFilters(allMergedPRs []ghPullRequest, config Config, sinceTag, untilTag *git.Tag, includeCommits []string, filters ...prFilter) []ghPullRequest {
 	// first pass: exclude PRs which are not within the date range derived from the tags
-	log.Trace("filtering PRs by chronology")
+	log.WithFields("input", len(allMergedPRs)).Trace("filtering PRs by chronology")
 	includedPRs, excludedPRs := filterPRs(allMergedPRs, standardChronologicalPrFilters(config, sinceTag, untilTag, includeCommits)...)
+	log.WithFields("kept", len(includedPRs), "dropped", len(excludedPRs)).Trace("PR chronology filter")
 
 	if config.ConsiderPRMergeCommits {
 		// second pass: include PRs that are outside of the date range but have commits within what is considered for release explicitly
 		log.Trace("considering re-inclusion of PRs based on merge commits")
-		includedPRs = append(includedPRs, keepPRsWithCommits(excludedPRs, includeCommits)...)
+		reincluded := keepPRsWithCommits(excludedPRs, includeCommits)
+		if len(reincluded) > 0 {
+			log.WithFields("count", len(reincluded)).Trace("PRs re-included by merge commit")
+		}
+		includedPRs = append(includedPRs, reincluded...)
 	}
 
 	// third pass: now that we have a list of PRs considered for release, we can filter down to those which have the correct traits (e.g. labels)
-	log.Trace("filtering remaining PRs by qualitative traits")
-	includedPRs, _ = filterPRs(includedPRs, filters...)
+	beforeQual := len(includedPRs)
+	var droppedQual []ghPullRequest
+	includedPRs, droppedQual = filterPRs(includedPRs, filters...)
+	log.WithFields("kept", len(includedPRs), "dropped", len(droppedQual), "input", beforeQual).Trace("PR qualitative filter")
 
 	return includedPRs
 }
@@ -332,7 +339,7 @@ func fetchMergedPRs(user, repo string, since *time.Time) ([]ghPullRequest, error
 
 			err := client.Query(context.Background(), &query, variables)
 			if err != nil {
-				return nil, err
+				return nil, explainGithubAPIError("query GitHub merged PRs", user, repo, err)
 			}
 
 			// limit = query.RateLimit

--- a/chronicle/release/releasers/github/gh_release.go
+++ b/chronicle/release/releasers/github/gh_release.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sort"
 	"time"
@@ -79,7 +80,7 @@ func fetchAllReleases(user, repo string) ([]ghRelease, error) {
 		for {
 			err := client.Query(context.Background(), &query, variables)
 			if err != nil {
-				return nil, err
+				return nil, explainGithubAPIError("query GitHub releases", user, repo, err)
 			}
 			// limit = query.RateLimit
 
@@ -149,7 +150,7 @@ func fetchRelease(user, repo, tag string) (*ghRelease, error) {
 
 	err := client.Query(context.Background(), &query, variables)
 	if err != nil {
-		return nil, err
+		return nil, explainGithubAPIError(fmt.Sprintf("query GitHub release tag=%q", tag), user, repo, err)
 	}
 
 	return &ghRelease{

--- a/chronicle/release/releasers/github/summarizer.go
+++ b/chronicle/release/releasers/github/summarizer.go
@@ -1,8 +1,10 @@
 package github
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -67,10 +69,16 @@ func NewSummarizer(gitter git.Interface, config Config) (*Summarizer, error) {
 
 	user, repo := extractGithubUserAndRepo(repoURL)
 	if user == "" || repo == "" {
-		return nil, fmt.Errorf("failed to extract owner and repo from %q", repoURL)
+		return nil, fmt.Errorf("could not extract GitHub owner/repo from remote URL %q (expected formats: git@github.com:owner/repo.git or https://github.com/owner/repo.git)", repoURL)
 	}
 
-	log.WithFields("owner", user, "repo", repo).Debug("github summarizer")
+	log.WithFields("owner", user, "repo", repo).Info("🎯 targeting GitHub repository")
+
+	if os.Getenv("GITHUB_TOKEN") == "" {
+		log.Warn("GITHUB_TOKEN environment variable is not set; GitHub API requests will be unauthenticated and likely fail or be rate-limited (set a token with 'repo' scope, or 'public_repo' for public repositories)")
+	} else {
+		log.Info("GitHub API authentication: using GITHUB_TOKEN")
+	}
 
 	return &Summarizer{
 		git:            gitter,
@@ -110,7 +118,7 @@ func (s *Summarizer) ChangesURL(sinceRef, untilRef string) string {
 func (s *Summarizer) LastRelease() (*release.Release, error) {
 	releases, err := fetchAllReleases(s.userName, s.repoName)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fetch all releases: %v", err)
+		return nil, fmt.Errorf("unable to fetch releases for %s/%s: %w", s.userName, s.repoName, err)
 	}
 	latestRelease := latestNonDraftRelease(releases)
 	if latestRelease != nil {
@@ -130,7 +138,7 @@ func (s *Summarizer) Changes(sinceRef, untilRef string) ([]change.Change, error)
 	}
 
 	if scope == nil {
-		return nil, fmt.Errorf("unable to find start and end of changes: %w", err)
+		return nil, errors.New("could not determine start/end of change range (no scope produced)")
 	}
 
 	logChangeScope(*scope, s.config.ConsiderPRMergeCommits)
@@ -168,7 +176,7 @@ func (s *Summarizer) getChangeScope(sinceRef, untilRef string) (*changeScope, er
 			IncludeEnd:   true,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("unable to fetch commit range: %v", err)
+			return nil, fmt.Errorf("unable to fetch commit range %q..%q: %w", sinceRef, untilRef, err)
 		}
 	}
 
@@ -231,7 +239,7 @@ func (s *Summarizer) changes(scope changeScope) ([]change.Change, error) {
 		return nil, err
 	}
 
-	log.WithFields("since", scope.Start.Timestamp).Debugf("total merged PRs discovered: %d", len(allMergedPRs))
+	log.WithFields("count", len(allMergedPRs), "since", scope.Start.Timestamp).Info("merged PRs discovered")
 
 	if s.config.IncludePRs {
 		changes = append(changes, changesFromStandardPRFilters(s.config, allMergedPRs, scope.Start.Tag, scope.End.Tag, scope.Commits)...)
@@ -246,7 +254,7 @@ func (s *Summarizer) changes(scope changeScope) ([]change.Change, error) {
 		allClosedIssues = filterIssues(allClosedIssues, excludeIssuesNotPlanned(allMergedPRs))
 	}
 
-	log.WithFields("since", scope.Start.Timestamp).Debugf("total closed issues discovered: %d", len(allClosedIssues))
+	log.WithFields("count", len(allClosedIssues), "since", scope.Start.Timestamp).Info("closed issues discovered")
 
 	if s.config.IncludeIssues {
 		if s.config.IssuesRequireLinkedPR {
@@ -269,11 +277,11 @@ func (s *Summarizer) changes(scope changeScope) ([]change.Change, error) {
 
 func logChangeScope(c changeScope, considerCommits bool) {
 	log.WithFields("since", c.Start.Ref, "until", c.End.Ref).Info("searching for changes")
-	log.WithFields(changePointFields(c.Start)).Debug("  ├── since")
-	log.WithFields(changePointFields(c.End)).Debug("  └── until")
+	log.WithFields(changePointFields(c.Start)).Info("  ├── since")
+	log.WithFields(changePointFields(c.End)).Info("  └── until")
 
 	if considerCommits {
-		log.Debugf("release comprises %d commits", len(c.Commits))
+		log.WithFields("count", len(c.Commits)).Info("release comprises commits")
 		logCommits(c.Commits)
 	}
 
@@ -368,9 +376,12 @@ func uniqueIssuesFromPRs(prs []ghPullRequest) []ghIssue {
 func changesFromStandardPRFilters(config Config, allMergedPRs []ghPullRequest, sinceTag, untilTag *git.Tag, includeCommits []string) []change.Change {
 	includedPRs := applyStandardPRFilters(allMergedPRs, config, sinceTag, untilTag, includeCommits)
 
-	includedPRs, _ = filterPRs(includedPRs, prsWithChangeTypes(config))
+	beforeChangeTypeFilter := len(includedPRs)
+	var droppedNoChangeType []ghPullRequest
+	includedPRs, droppedNoChangeType = filterPRs(includedPRs, prsWithChangeTypes(config))
+	log.WithFields("kept", len(includedPRs), "dropped", len(droppedNoChangeType), "input", beforeChangeTypeFilter).Trace("PR change-type filter")
 
-	log.Debugf("PRs contributing to changelog: %d", len(includedPRs))
+	log.WithFields("count", len(includedPRs)).Info("PRs contributing to changelog")
 	logPRs(includedPRs)
 
 	return createChangesFromPRs(config, includedPRs)
@@ -412,7 +423,7 @@ func logPRs(prs []ghPullRequest) {
 		if idx == len(prs)-1 {
 			branch = treeLeaf
 		}
-		log.Tracef("  %s #%d: merged %s", branch, pr.Number, internal.FormatDateTime(pr.MergedAt))
+		log.Debugf("  %s #%d: merged %s", branch, pr.Number, internal.FormatDateTime(pr.MergedAt))
 	}
 }
 
@@ -423,7 +434,7 @@ func changesFromIssuesLinkedToPrs(config Config, allMergedPRs []ghPullRequest, s
 	issues := issuesExtractedFromPRs(config, allMergedPRs, sinceTag, untilTag, includeCommits)
 	issues = filterIssues(issues, issuesWithChangeTypes(config))
 
-	log.Debugf("linked issues contributing to changelog: %d", len(issues))
+	log.WithFields("count", len(issues)).Info("linked issues contributing to changelog")
 	logIssues(issues)
 
 	return createChangesFromIssues(config, allMergedPRs, issues)
@@ -434,7 +445,7 @@ func changesFromIssues(config Config, allMergedPRs []ghPullRequest, allClosedIss
 
 	filteredIssues = filterIssues(filteredIssues, issuesWithChangeTypes(config))
 
-	log.Debugf("issues contributing to changelog: %d", len(filteredIssues))
+	log.WithFields("count", len(filteredIssues)).Info("issues contributing to changelog")
 	logIssues(filteredIssues)
 
 	return createChangesFromIssues(config, allMergedPRs, filteredIssues)
@@ -446,7 +457,7 @@ func logIssues(issues []ghIssue) {
 		if idx == len(issues)-1 {
 			branch = treeLeaf
 		}
-		log.Tracef("  %s #%d: closed %s", branch, issue.Number, internal.FormatDateTime(issue.ClosedAt))
+		log.Debugf("  %s #%d: closed %s", branch, issue.Number, internal.FormatDateTime(issue.ClosedAt))
 	}
 }
 
@@ -461,7 +472,8 @@ func changesFromUnlabeledPRs(config Config, allMergedPRs []ghPullRequest, sinceT
 
 	filteredIssues, _ := filterPRs(allMergedPRs, filters...)
 
-	log.Debugf("unlabeled PRs contributing to changelog: %d", len(filteredIssues))
+	log.WithFields("count", len(filteredIssues)).Info("unlabeled PRs contributing to changelog")
+	logPRs(filteredIssues)
 
 	return createChangesFromPRs(config, filteredIssues)
 }
@@ -474,7 +486,8 @@ func changesFromUnlabeledIssues(config Config, allMergedPRs []ghPullRequest, all
 
 	filteredIssues := filterIssues(allIssues, filters...)
 
-	log.Debugf("unlabeled issues contributing to changelog: %d", len(filteredIssues))
+	log.WithFields("count", len(filteredIssues)).Info("unlabeled issues contributing to changelog")
+	logIssues(filteredIssues)
 
 	return createChangesFromIssues(config, allMergedPRs, filteredIssues)
 }

--- a/cmd/chronicle/cli/commands/create.go
+++ b/cmd/chronicle/cli/commands/create.go
@@ -30,27 +30,40 @@ Create a changelog representing the changes from tag v0.14.0 until v0.18.0 (for 
 	chronicle --since-tag v0.14.0 --until-tag v0.18.0 ../path/to/repo
 
 `,
-		Args: func(cmd *cobra.Command, args []string) error {
-			if err := cobra.MaximumNArgs(1)(cmd, args); err != nil {
-				_ = cmd.Help()
-				return err
-			}
-			var repo = "./"
-			if len(args) == 1 {
-				if !git.IsRepository(args[0]) {
-					return fmt.Errorf("given path is not a git repository: %s", args[0])
-				}
-				repo = args[0]
-			} else {
-				log.Infof("no repository path given, assuming %q", repo)
-			}
-			appConfig.RepoPath = repo
-			return nil
-		},
-		RunE: func(_ *cobra.Command, _ []string) error {
+		Args: repoPathArgs(appConfig),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// ensure errors are printed to stderr since most output is redirected to CHANGELOG.md more often than not
+			cmd.SetErr(os.Stderr)
 			return runCreate(appConfig)
 		},
 	}, appConfig)
+}
+
+// repoPathArgs returns a cobra Args validator that resolves an optional [PATH] argument and writes
+// it onto the given config. It must be a factory (rather than a method on createConfig or a free
+// function that takes config from a closure of a different command) so that root and create each
+// pin the validator to their own config — sharing one validator across both commands previously
+// caused root invocations to leave RepoPath empty.
+func repoPathArgs(cfg *createConfig) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := cobra.MaximumNArgs(1)(cmd, args); err != nil {
+			_ = cmd.Help()
+			return err
+		}
+		var repo = "./"
+		if len(args) == 1 {
+			repo = args[0]
+		} else {
+			log.Infof("no repository path given, assuming %q", repo)
+		}
+		// validate now (rather than deferring to git.New deep in the worker) so the user gets a
+		// clear, early failure with the underlying go-git reason, including for the implicit "./".
+		if _, err := git.New(repo); err != nil {
+			return err
+		}
+		cfg.RepoPath = repo
+		return nil
+	}
 }
 
 func runCreate(appConfig *createConfig) error {

--- a/cmd/chronicle/cli/commands/create_github_worker.go
+++ b/cmd/chronicle/cli/commands/create_github_worker.go
@@ -34,9 +34,9 @@ func createChangelogFromGithub(appConfig *createConfig) (*release.Release, *rele
 	}
 
 	if untilTag != "" {
-		log.WithFields("tag", untilTag).Trace("until the given tag")
+		log.WithFields("tag", untilTag).Info("until the given tag")
 	} else {
-		log.Trace("until the current revision")
+		log.Info("until the current revision (no end tag)")
 	}
 
 	var speculator release.VersionSpeculator

--- a/cmd/chronicle/cli/commands/next_version.go
+++ b/cmd/chronicle/cli/commands/next_version.go
@@ -46,7 +46,9 @@ func NextVersion(app clio.Application) *cobra.Command {
 			cfg.RepoPath = repo
 			return nil
 		},
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// ensure errors are printed to stderr since most output is redirected to CHANGELOG.md more often than not
+			cmd.SetErr(os.Stderr)
 			return runNextVersion(cfg)
 		},
 	}, cfg)

--- a/cmd/chronicle/cli/commands/root.go
+++ b/cmd/chronicle/cli/commands/root.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/anchore/clio"
@@ -12,8 +14,12 @@ func Root(app clio.Application, createCmd *cobra.Command) *cobra.Command {
 	cmd := app.SetupRootCommand(&cobra.Command{
 		Short: createCmd.Short,
 		Long:  createCmd.Long,
-		Args:  createCmd.Args,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		// pin the Args validator to root's own config — using createCmd.Args here would close over
+		// create's config and leave root's RepoPath empty.
+		Args: repoPathArgs(appConfig),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// ensure errors are printed to stderr since most output is redirected to CHANGELOG.md more often than not
+			cmd.SetErr(os.Stderr)
 			return runCreate(appConfig)
 		},
 	}, appConfig)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/anchore/go-logger v0.0.0-20250318195838-07ae343dd722
 	github.com/coreos/go-semver v0.3.1
 	github.com/gkampitakis/go-snaps v0.5.21
+	github.com/go-git/go-billy/v5 v5.8.0
 	github.com/go-git/go-git/v5 v5.17.1
 	github.com/google/go-cmp v0.7.0
 	github.com/leodido/go-conventionalcommits v0.12.0
@@ -34,7 +35,6 @@ require (
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/gkampitakis/ciinfo v0.3.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.8.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-yaml v1.18.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect

--- a/internal/git/first.go
+++ b/internal/git/first.go
@@ -8,7 +8,7 @@ import (
 )
 
 func FirstCommit(repoPath string) (string, error) {
-	r, err := git.PlainOpen(repoPath)
+	r, err := openRepo(repoPath)
 	if err != nil {
 		return "", fmt.Errorf("unable to open repo: %w", err)
 	}

--- a/internal/git/head.go
+++ b/internal/git/head.go
@@ -1,11 +1,16 @@
 package git
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+
+	"github.com/anchore/chronicle/internal/log"
 )
+
+// errStopIter is a sentinel used to short-circuit a tag-ref iteration once we've found a match.
+var errStopIter = errors.New("stop iteration")
 
 func HeadTagOrCommit(repoPath string) (string, error) {
 	return headTag(repoPath, true)
@@ -16,29 +21,33 @@ func HeadTag(repoPath string) (string, error) {
 }
 
 func headTag(repoPath string, orCommit bool) (string, error) {
-	r, err := git.PlainOpen(repoPath)
+	r, err := openRepo(repoPath)
 	if err != nil {
-		return "", fmt.Errorf("unable to open repo: %w", err)
+		return "", fmt.Errorf("unable to open repo %q: %w", repoPath, err)
 	}
 	ref, err := r.Head()
 	if err != nil {
-		return "", fmt.Errorf("unable fetch head: %w", err)
+		return "", fmt.Errorf("unable to fetch HEAD reference: %w", err)
 	}
 
-	tagRefs, _ := r.Tags()
-	var tagName string
+	tagRefs, err := r.Tags()
+	if err != nil {
+		return "", fmt.Errorf("unable to enumerate tags: %w", err)
+	}
 
-	_ = tagRefs.ForEach(func(t *plumbing.Reference) error {
+	var tagName string
+	iterErr := tagRefs.ForEach(func(t *plumbing.Reference) error {
 		if t.Hash().String() == ref.Hash().String() {
-			// for lightweight tags
+			// for lightweight tags, the tag hash points directly to the commit
 			tagName = t.Name().Short()
-			return fmt.Errorf("found")
+			return errStopIter
 		}
 
-		// this is an annotated tag... since annotated tags are stored within their own commit we need to resolve the
-		// revision to get the commit the tag object points to (that is the commit with the code blob).
+		// for annotated tags we need to resolve the revision to get the commit the tag object points at
 		revHash, err := r.ResolveRevision(plumbing.Revision(t.Name()))
 		if err != nil {
+			// some refs may not resolve (e.g. dangling tag objects); record and continue rather than fail the whole walk
+			log.WithFields("ref", t.Name().String(), "error", err).Trace("skipping unresolvable tag ref")
 			return nil
 		}
 
@@ -48,10 +57,13 @@ func headTag(repoPath string, orCommit bool) (string, error) {
 
 		if *revHash == ref.Hash() {
 			tagName = t.Name().Short()
-			return fmt.Errorf("found")
+			return errStopIter
 		}
 		return nil
 	})
+	if iterErr != nil && !errors.Is(iterErr, errStopIter) {
+		return "", fmt.Errorf("error while walking tag references: %w", iterErr)
+	}
 
 	if tagName != "" {
 		return tagName, nil
@@ -64,13 +76,13 @@ func headTag(repoPath string, orCommit bool) (string, error) {
 }
 
 func HeadCommit(repoPath string) (string, error) {
-	r, err := git.PlainOpen(repoPath)
+	r, err := openRepo(repoPath)
 	if err != nil {
-		return "", fmt.Errorf("unable to open repo: %w", err)
+		return "", fmt.Errorf("unable to open repo %q: %w", repoPath, err)
 	}
 	ref, err := r.Head()
 	if err != nil {
-		return "", fmt.Errorf("unable fetch head: %w", err)
+		return "", fmt.Errorf("unable to fetch HEAD reference: %w", err)
 	}
 	return ref.Hash().String(), nil
 }

--- a/internal/git/interface.go
+++ b/internal/git/interface.go
@@ -1,6 +1,9 @@
 package git
 
-import "fmt"
+import (
+	"fmt"
+	"path/filepath"
+)
 
 var _ Interface = (*gitter)(nil)
 
@@ -19,8 +22,12 @@ type gitter struct {
 }
 
 func New(repoPath string) (Interface, error) {
-	if !IsRepository(repoPath) {
-		return nil, fmt.Errorf("not a git repository: %q", repoPath)
+	if _, err := openRepo(repoPath); err != nil {
+		abs, absErr := filepath.Abs(repoPath)
+		if absErr != nil {
+			abs = repoPath
+		}
+		return nil, fmt.Errorf("could not open git repository at %q (resolved to %q): %w", repoPath, abs, err)
 	}
 	return gitter{
 		repoPath: repoPath,

--- a/internal/git/is_repository.go
+++ b/internal/git/is_repository.go
@@ -1,13 +1,203 @@
 package git
 
 import (
-	"github.com/go-git/go-git/v5"
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/osfs"
+	gogit "github.com/go-git/go-git/v5"
+	gogitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/cache"
+	rawconfig "github.com/go-git/go-git/v5/plumbing/format/config"
+	"github.com/go-git/go-git/v5/storage/filesystem"
+
+	"github.com/anchore/chronicle/internal/log"
 )
 
-func IsRepository(path string) bool {
-	r, err := git.PlainOpen(path)
-	if err != nil {
+// openRepo opens a git repository at the given path. It tries, in order:
+//  1. a strict open at the path (the common case).
+//  2. a fallback that walks parent directories and follows .git-as-file pointers
+//     (handles git worktrees, submodules, and being run from a subdirectory).
+//  3. a last-resort lenient open that bypasses go-git's overly strict branch
+//     config validation. Real `git` accepts configs (e.g. branch.<name>.merge
+//     pointing at non-branch refs) that go-git rejects with errors like
+//     "branch config: invalid merge"; we skip those branch entries since
+//     chronicle does not read branch tracking config.
+//
+// On failure the returned error contains the underlying go-git reason.
+func openRepo(path string) (*gogit.Repository, error) {
+	if r, err := gogit.PlainOpen(path); err == nil {
+		return r, nil
+	} else if !isConfigValidationErr(err) {
+		// remember the strict error in case the fallbacks turn up nothing more useful
+		strictErr := err
+
+		if r, err := gogit.PlainOpenWithOptions(path, &gogit.PlainOpenOptions{
+			DetectDotGit:          true,
+			EnableDotGitCommonDir: true,
+		}); err == nil {
+			return r, nil
+		} else if !isConfigValidationErr(err) {
+			if errors.Is(strictErr, gogit.ErrRepositoryNotExists) {
+				return nil, strictErr
+			}
+			return nil, err
+		}
+	}
+
+	// at least one open path failed with a config-validation error; attempt a lenient open
+	r, lenErr := openLenient(path)
+	if lenErr != nil {
+		return nil, lenErr
+	}
+	return r, nil
+}
+
+// isConfigValidationErr reports whether the error came from go-git's config validator
+// (rather than e.g. a missing repository or unreadable file).
+func isConfigValidationErr(err error) bool {
+	if err == nil {
 		return false
 	}
-	return r != nil
+	msg := err.Error()
+	return strings.Contains(msg, "branch config:") ||
+		strings.Contains(msg, "remote config:") ||
+		errors.Is(err, gogitconfig.ErrInvalid)
+}
+
+// openLenient opens a repository while bypassing go-git's strict config validation by
+// pre-sanitizing the .git/config bytes before they reach go-git's parser.
+func openLenient(path string) (*gogit.Repository, error) {
+	// resolve dot-git and worktree filesystems the same way PlainOpenWithOptions does, but
+	// without going through the validating Open helper.
+	dot, wt, err := resolveDotGit(path)
+	if err != nil {
+		return nil, err
+	}
+
+	configBytes, err := readFile(dot, "config")
+	if err != nil {
+		return nil, err
+	}
+
+	cleaned, dropped := stripInvalidBranches(configBytes)
+	if len(dropped) > 0 {
+		// emitted once per openRepo call, which can be many times per run — trace-only since the
+		// underlying condition is benign (real git tolerates these branch configs; chronicle does
+		// not read them at all).
+		log.WithFields("branches", strings.Join(dropped, ",")).Trace("skipping branch config entries rejected by go-git's stricter validator")
+	}
+
+	storer := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	lenient := &lenientStorage{Storage: storer, sanitizedConfig: cleaned}
+
+	return gogit.Open(lenient, wt)
+}
+
+// lenientStorage wraps a filesystem.Storage and overrides Config() to return a config parsed from
+// pre-sanitized bytes, side-stepping go-git's overly strict branch validation.
+type lenientStorage struct {
+	*filesystem.Storage
+	sanitizedConfig []byte
+}
+
+func (l *lenientStorage) Config() (*gogitconfig.Config, error) {
+	cfg := gogitconfig.NewConfig()
+	if err := cfg.Unmarshal(l.sanitizedConfig); err != nil {
+		// fall back to the original Storage.Config so the caller sees the real error
+		return l.Storage.Config()
+	}
+	return cfg, nil
+}
+
+func (l *lenientStorage) SetConfig(cfg *gogitconfig.Config) error {
+	return l.Storage.SetConfig(cfg)
+}
+
+// stripInvalidBranches removes [branch "X"] subsections whose `merge` value would fail
+// go-git's Branch.Validate (Merge must be a branch ref). Real git accepts configs like
+// `merge = refs/tags/...` or arbitrary strings; chronicle does not consult this metadata.
+// Returns the cleaned config bytes and the names of any branches that were dropped.
+func stripInvalidBranches(b []byte) ([]byte, []string) {
+	raw := rawconfig.New()
+	if err := rawconfig.NewDecoder(bytes.NewReader(b)).Decode(raw); err != nil {
+		return b, nil
+	}
+
+	var dropped []string
+	for _, section := range raw.Sections {
+		if section.Name != "branch" {
+			continue
+		}
+		kept := section.Subsections[:0]
+		for _, sub := range section.Subsections {
+			merge := plumbing.ReferenceName(sub.Options.Get("merge"))
+			if merge != "" && !merge.IsBranch() {
+				dropped = append(dropped, sub.Name)
+				continue
+			}
+			kept = append(kept, sub)
+		}
+		section.Subsections = kept
+	}
+
+	var buf bytes.Buffer
+	if err := rawconfig.NewEncoder(&buf).Encode(raw); err != nil {
+		return b, nil
+	}
+	return buf.Bytes(), dropped
+}
+
+func resolveDotGit(path string) (dot, wt billy.Filesystem, err error) {
+	// reuse PlainOpenWithOptions's behavior by attempting a one-shot open; if it fails for the
+	// config reason we still got the dot/worktree filesystems wired up via osfs below. This is a
+	// minimal re-implementation of go-git's dotGitToOSFilesystems that handles plain repos and
+	// .git-as-file (gitdir pointer) layouts.
+	wt = osfs.New(path)
+	dot, err = wt.Chroot(".git")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// if .git is a regular file (worktree/submodule), follow its `gitdir:` pointer
+	fi, statErr := wt.Stat(".git")
+	if statErr == nil && !fi.IsDir() {
+		f, openErr := wt.Open(".git")
+		if openErr != nil {
+			return nil, nil, openErr
+		}
+		defer f.Close()
+		buf, readErr := io.ReadAll(f)
+		if readErr != nil {
+			return nil, nil, readErr
+		}
+		line := strings.TrimSpace(string(buf))
+		const prefix = "gitdir:"
+		if strings.HasPrefix(line, prefix) {
+			gitdir := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+			dot = osfs.New(gitdir)
+		}
+	}
+
+	return dot, wt, nil
+}
+
+func readFile(fs billy.Filesystem, name string) ([]byte, error) {
+	f, err := fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return io.ReadAll(f)
+}
+
+// IsRepository reports whether the given path can be opened as a git repository.
+// Prefer openRepo / git.New when you also want the underlying error.
+func IsRepository(path string) bool {
+	_, err := openRepo(path)
+	return err == nil
 }

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -14,17 +14,23 @@ var remotePattern = regexp.MustCompile(`\[remote\s*"origin"]\s*\n\s*url\s*=\s*(?
 
 // TODO: can't use r.Config for same validation reasons
 func RemoteURL(p string) (string, error) {
-	f, err := os.Open(path.Join(p, ".git", "config"))
+	cfgPath := path.Join(p, ".git", "config")
+	f, err := os.Open(cfgPath)
 	if err != nil {
-		return "", fmt.Errorf("unable to open git config: %w", err)
+		return "", fmt.Errorf("unable to open git config %q: %w", cfgPath, err)
 	}
 	contents, err := io.ReadAll(f)
 	if err != nil {
-		return "", fmt.Errorf("unable to read git config: %w", err)
+		return "", fmt.Errorf("unable to read git config %q: %w", cfgPath, err)
 	}
 	matches := internal.MatchNamedCaptureGroups(remotePattern, string(contents))
 
-	return matches["url"], nil
+	url := matches["url"]
+	if url == "" {
+		return "", fmt.Errorf("no 'origin' remote URL found in %q (chronicle requires an 'origin' remote pointing to GitHub)", cfgPath)
+	}
+
+	return url, nil
 }
 
 // TODO: can't use r.Config for same validation reasons

--- a/internal/git/tag.go
+++ b/internal/git/tag.go
@@ -28,7 +28,7 @@ type Range struct {
 }
 
 func CommitsBetween(repoPath string, cfg Range) ([]string, error) {
-	r, err := git.PlainOpen(repoPath)
+	r, err := openRepo(repoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -73,12 +73,15 @@ func CommitsBetween(repoPath string, cfg Range) ([]string, error) {
 
 		return
 	})
+	if err != nil {
+		return nil, fmt.Errorf("error walking commits between %q..%q: %w", cfg.SinceRef, cfg.UntilRef, err)
+	}
 
-	return commits, err
+	return commits, nil
 }
 
 func SearchForTag(repoPath, tagRef string) (*Tag, error) {
-	r, err := git.PlainOpen(repoPath)
+	r, err := openRepo(repoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +99,7 @@ func SearchForTag(repoPath, tagRef string) (*Tag, error) {
 }
 
 func TagsFromLocal(repoPath string) ([]Tag, error) {
-	r, err := git.PlainOpen(repoPath)
+	r, err := openRepo(repoPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A bunch of error messages used to vanish or come out as bare strings with no context, and `-v` didn't really tell you what chronicle was doing. This fixes both.

Once errors actually surfaced, a few latent bugs became obvious (root-command Args closure, swallowed iteration errors in `head.go`, a guaranteed-nil `%w` wrap), so squashing them in the same PR made more sense than splitting... the visibility work is what made them findable.

Errors that were getting swallowed or were unhelpful:
- `RemoteURL` quietly returned `"", nil` on regex miss; now errors with `no 'origin' remote URL found in <path>`.
- `head.go` discarded `r.Tags()` and `tagRefs.ForEach()` errors and used `fmt.Errorf("found")` as a stop sentinel indistinguishable from real failures. Both errors surfaced now via a proper `errStopIter` sentinel.
- `CommitsBetween` no longer returns partial commits alongside an error; iteration error is wrapped with since/until refs.
- A few `%v` wraps switched to `%w` so `errors.Is`/`As` chains work; one `%w` wrap of a guaranteed-nil `err` (rendering `%!w(<nil>)`) replaced with a plain error.
- `git.New` returns `could not open git repository at %q (resolved to %q): %w` instead of just refusing with a boolean.

GitHub API errors are way more actionable:
- New `explainGithubAPIError` annotates every `client.Query` site with status-specific hints: 401 → set `GITHUB_TOKEN` with repo scope, 403 → rate-limited or missing scopes, 404 → repo not found.
- `NewSummarizer` warns up front if `GITHUB_TOKEN` isn't set, logs authenticated state when it is (token value never logged).
- `find_changelog_end_tag` no longer treats every release-fetch error as "no release exists"; only the actual GraphQL not-found responses are swallowed, everything else propagates.

go-git's config validator is stricter than real `git` and refuses to open repos with things like `branch.X.merge` pointing at a non-branch ref. Chronicle doesn't read branch tracking metadata, so a new `openRepo` helper (used at every `git.PlainOpen` callsite) tries strict open, then `PlainOpenWithOptions{DetectDotGit, EnableDotGitCommonDir}` for worktrees / submodules / subdir invocation, then a lenient last-resort that strips offending `[branch "X"]` subsections from `.git/config` before feeding it to `git.Open`.

Two root-command bugs:
- `root.go` had `Args: createCmd.Args`, which closed over `create`'s `appConfig`... so the root form (`chronicle <path>`) populated the wrong config and died with `not a git repository: ""`. Args is now a factory `repoPathArgs(*createConfig)` so each command pins it to its own config. The validator also now calls `git.New` instead of the boolean `IsRepository`, so the real reason surfaces at arg-validation time.
- Each `RunE` pins `cmd.SetErr(os.Stderr)` defensively. Stdout is reserved for the changelog report... an older clio version this project once shipped against sent errors to stdout, which silently corrupted `chronicle > CHANGELOG.md`.

INFO logging now tells a story:
- A default `-v` run now reads as a story: target repo, auth state, since/until anchors, discovery counts, contribution counts, final change-type breakdown... pulled up from DEBUG/TRACE.
- Counts and per-type breakdowns are structured fields, so the log is grep-friendly. DEBUG still carries per-PR / per-issue / per-commit evidence trees beneath each rollup.
- Three emoji anchors mark phase boundaries (🎯 target, 📝 discovered changes, 🔮 speculated version); every other INFO line is plain so the anchors stand out.

Tested with `go test ./...` (clean) and run end-to-end against chronicle and syft (syft has the funky branch configs that exercise the lenient-open path).
