### PR TITLE
Smaller query for listing releases is faster

### DIFF
--- a/chronicle/release/releasers/github/gh_release.go
+++ b/chronicle/release/releasers/github/gh_release.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sort"
 	"time"
 
 	"github.com/shurcooL/githubv4"
@@ -20,96 +19,76 @@ type ghRelease struct {
 	IsDraft  bool
 }
 
-func latestNonDraftRelease(releases []ghRelease) *ghRelease {
-	for i := len(releases) - 1; i >= 0; i-- {
-		if !releases[i].IsDraft {
-			return &releases[i]
-		}
-	}
-	return nil
-}
-
-func fetchAllReleases(user, repo string) ([]ghRelease, error) {
+// fetchLatestNonDraftRelease returns the most recently created non-draft release for the given repo,
+// or nil if the repo has no non-draft releases. It queries newest-first and returns on the first
+// non-draft hit, only paginating if an entire page is drafts (rare in practice).
+func fetchLatestNonDraftRelease(user, repo string) (*ghRelease, error) {
 	src := oauth2.StaticTokenSource(
 		// TODO: DI this
 		&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
 	)
 	httpClient := oauth2.NewClient(context.Background(), src)
 	client := githubv4.NewClient(httpClient)
-	var allReleases []ghRelease
 
-	// Query some details about a repository, an ghIssue in it, and its comments.
-	{
-		// TODO: act on hitting a rate limit
-		type rateLimit struct {
-			Cost      githubv4.Int
-			Limit     githubv4.Int
-			Remaining githubv4.Int
-			ResetAt   githubv4.DateTime
-		}
-
-		var query struct {
-			Repository struct {
-				DatabaseID githubv4.Int
-				URL        githubv4.URI
-				Releases   struct {
-					PageInfo struct {
-						EndCursor   githubv4.String
-						HasNextPage bool
-					}
-					Edges []struct {
-						Node struct {
-							TagName     githubv4.String
-							IsLatest    githubv4.Boolean
-							IsDraft     githubv4.Boolean
-							PublishedAt githubv4.DateTime
-						}
-					}
-				} `graphql:"releases(first:100, after:$releasesCursor)"`
-			} `graphql:"repository(owner:$repositoryOwner, name:$repositoryName)"`
-
-			RateLimit rateLimit
-		}
-		variables := map[string]interface{}{
-			"repositoryOwner": githubv4.String(user),
-			"repositoryName":  githubv4.String(repo),
-			"releasesCursor":  (*githubv4.String)(nil), // Null after argument to get first page.
-		}
-
-		// var limit rateLimit
-		for {
-			err := client.Query(context.Background(), &query, variables)
-			if err != nil {
-				return nil, explainGithubAPIError("query GitHub releases", user, repo, err)
-			}
-			// limit = query.RateLimit
-
-			for _, iEdge := range query.Repository.Releases.Edges {
-				allReleases = append(allReleases, ghRelease{
-					Tag:      string(iEdge.Node.TagName),
-					IsLatest: bool(iEdge.Node.IsLatest),
-					IsDraft:  bool(iEdge.Node.IsDraft),
-					Date:     iEdge.Node.PublishedAt.Time,
-				})
-			}
-
-			if !query.Repository.Releases.PageInfo.HasNextPage {
-				break
-			}
-			variables["releasesCursor"] = githubv4.NewString(query.Repository.Releases.PageInfo.EndCursor)
-		}
-
-		// for idx, is := range allReleases {
-		//	fmt.Printf("%d: %+v\n", idx, is)
-		//}
-		// printJSON(limit)
+	// TODO: act on hitting a rate limit
+	type rateLimit struct {
+		Cost      githubv4.Int
+		Limit     githubv4.Int
+		Remaining githubv4.Int
+		ResetAt   githubv4.DateTime
 	}
 
-	sort.Slice(allReleases, func(i, j int) bool {
-		return allReleases[i].Date.Before(allReleases[j].Date)
-	})
+	var query struct {
+		Repository struct {
+			DatabaseID githubv4.Int
+			URL        githubv4.URI
+			Releases   struct {
+				PageInfo struct {
+					EndCursor   githubv4.String
+					HasNextPage bool
+				}
+				Edges []struct {
+					Node struct {
+						TagName     githubv4.String
+						IsLatest    githubv4.Boolean
+						IsDraft     githubv4.Boolean
+						PublishedAt githubv4.DateTime
+					}
+				}
+			} `graphql:"releases(first:100, after:$releasesCursor, orderBy:{field:CREATED_AT, direction:DESC})"`
+		} `graphql:"repository(owner:$repositoryOwner, name:$repositoryName)"`
 
-	return allReleases, nil
+		RateLimit rateLimit
+	}
+	variables := map[string]interface{}{
+		"repositoryOwner": githubv4.String(user),
+		"repositoryName":  githubv4.String(repo),
+		"releasesCursor":  (*githubv4.String)(nil), // null after argument to get first page.
+	}
+
+	for {
+		err := client.Query(context.Background(), &query, variables)
+		if err != nil {
+			return nil, explainGithubAPIError("query GitHub releases", user, repo, err)
+		}
+
+		for _, edge := range query.Repository.Releases.Edges {
+			if bool(edge.Node.IsDraft) {
+				continue
+			}
+			return &ghRelease{
+				Tag:      string(edge.Node.TagName),
+				IsLatest: bool(edge.Node.IsLatest),
+				IsDraft:  bool(edge.Node.IsDraft),
+				Date:     edge.Node.PublishedAt.Time,
+			}, nil
+		}
+
+		if !query.Repository.Releases.PageInfo.HasNextPage {
+			return nil, nil
+		}
+		variables["releasesCursor"] = githubv4.NewString(query.Repository.Releases.PageInfo.EndCursor)
+	}
 }
 
 func fetchRelease(user, repo, tag string) (*ghRelease, error) {

--- a/chronicle/release/releasers/github/summarizer.go
+++ b/chronicle/release/releasers/github/summarizer.go
@@ -116,11 +116,10 @@ func (s *Summarizer) ChangesURL(sinceRef, untilRef string) string {
 }
 
 func (s *Summarizer) LastRelease() (*release.Release, error) {
-	releases, err := fetchAllReleases(s.userName, s.repoName)
+	latestRelease, err := fetchLatestNonDraftRelease(s.userName, s.repoName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch releases for %s/%s: %w", s.userName, s.repoName, err)
 	}
-	latestRelease := latestNonDraftRelease(releases)
 	if latestRelease != nil {
 		return &release.Release{
 			Version: latestRelease.Tag,


### PR DESCRIPTION
We don't need to query for all releases, only the set of recent releases until you find the latest release. This cuts off a significant amount of time for repos with a lot of releases (like syft).