### PR TITLE
Add trunk output encoder

### DIFF
--- a/chronicle/release/changelog_info.go
+++ b/chronicle/release/changelog_info.go
@@ -35,9 +35,18 @@ func ChangelogInfo(summer Summarizer, config ChangelogInfoConfig) (*Release, *De
 		log.Info("since the beginning of git history")
 	}
 
-	releaseVersion, changes, err := changelogChanges(startReleaseVersion, summer, config)
+	releaseVersion, changes, speculated, err := changelogChangesWithSpeculation(startReleaseVersion, summer, config)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// fetch trunk data if the summarizer supports it
+	var trunkData *TrunkData
+	if ts, ok := summer.(TrunkSummarizer); ok {
+		trunkData, err = ts.Trunk(startReleaseVersion, config.UntilTag)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to fetch trunk data: %w", err)
+		}
 	}
 
 	var releaseDisplayVersion = releaseVersion
@@ -57,31 +66,38 @@ func ChangelogInfo(summer Summarizer, config ChangelogInfoConfig) (*Release, *De
 		Changes:          changes,
 		SupportedChanges: config.ChangeTypeTitles,
 		Notice:           "", // TODO...
+		PreviousRelease:  startRelease,
+		Speculated:       speculated,
+		Trunk:            trunkData,
 	}, nil
 }
 
-func changelogChanges(startReleaseVersion string, summer Summarizer, config ChangelogInfoConfig) (string, []change.Change, error) {
+// changelogChangesWithSpeculation returns the resolved end-release version and the set of
+// changes between startReleaseVersion and the configured UntilTag (speculating the version
+// when needed), and reports whether the release version was produced by the speculator.
+func changelogChangesWithSpeculation(startReleaseVersion string, summer Summarizer, config ChangelogInfoConfig) (releaseVersion string, changes []change.Change, speculated bool, err error) {
 	endReleaseVersion := config.UntilTag
 
-	changes, err := summer.Changes(startReleaseVersion, config.UntilTag)
+	changes, err = summer.Changes(startReleaseVersion, config.UntilTag)
 	if err != nil {
-		return "", nil, fmt.Errorf("unable to summarize changes: %w", err)
+		return "", nil, false, fmt.Errorf("unable to summarize changes: %w", err)
 	}
 
 	if config.VersionSpeculator != nil {
 		if endReleaseVersion == "" {
-			specEndReleaseVersion, err := speculateNextVersion(config.VersionSpeculator, startReleaseVersion, changes)
-			if err != nil {
-				log.Warnf("unable to speculate next release version: %+v", err)
+			specEndReleaseVersion, specErr := speculateNextVersion(config.VersionSpeculator, startReleaseVersion, changes)
+			if specErr != nil {
+				log.Warnf("unable to speculate next release version: %+v", specErr)
 			} else {
 				endReleaseVersion = specEndReleaseVersion
+				speculated = true
 			}
 		} else {
 			log.Infof("not speculating next version current head tag=%q", endReleaseVersion)
 		}
 	}
 
-	return endReleaseVersion, changes, nil
+	return endReleaseVersion, changes, speculated, nil
 }
 
 func speculateNextVersion(speculator VersionSpeculator, startReleaseVersion string, changes []change.Change) (string, error) {

--- a/chronicle/release/changelog_info_test.go
+++ b/chronicle/release/changelog_info_test.go
@@ -88,7 +88,7 @@ func TestChangelogInfo_NoRelease(t *testing.T) {
 	assert.Equal(t, "https://github.com/owner/repo/commits/v0.1.0", description.VCSChangesURL)
 }
 
-func Test_changelogChanges(t *testing.T) {
+func Test_changelogChangesWithSpeculation(t *testing.T) {
 	tests := []struct {
 		name                string
 		startReleaseVersion string
@@ -130,7 +130,7 @@ func Test_changelogChanges(t *testing.T) {
 			if tt.wantErr == nil {
 				tt.wantErr = require.NoError
 			}
-			endReleaseVersion, _, err := changelogChanges(tt.startReleaseVersion, tt.summer, tt.config)
+			endReleaseVersion, _, _, err := changelogChangesWithSpeculation(tt.startReleaseVersion, tt.summer, tt.config)
 			tt.wantErr(t, err)
 
 			assert.Equal(t, tt.endReleaseVersion, endReleaseVersion)

--- a/chronicle/release/description.go
+++ b/chronicle/release/description.go
@@ -10,4 +10,7 @@ type Description struct {
 	Notice           string             // manual note or summary that describes the changelog at a high level
 	Changes          change.Changes     // all issues and PRs that makeup this release
 	SupportedChanges []change.TypeTitle // the sections of the changelog and their display titles
+	PreviousRelease  *Release           // the release this changelog starts from; nil if since the beginning of history
+	Speculated       bool               // true when the version was inferred by the speculator
+	Trunk            *TrunkData         // optional, populated by summarizers that implement TrunkSummarizer
 }

--- a/chronicle/release/output/encoders/trunk/__snapshots__/encoder_test.snap
+++ b/chronicle/release/output/encoders/trunk/__snapshots__/encoder_test.snap
@@ -1,0 +1,101 @@
+
+[TestEncoder_Encode/condensed,_hide-filtered,_with_previous_release - 1]
+◆  v0.5.0  ‹2026-05-07›
+│  commit   pr    title                         closes      type / filter reason
+│
+●  a1b2c3d  #466  feat: multi-output formats    #450, #451  enhancement
+│
+●  1234567  #470  fix: nil deref in summarizer  #468        bug
+│
+◆  v0.4.1  ‹2026-04-18›
+
+---
+
+[TestEncoder_Encode/condensed,_show-filtered,_with_previous_release - 1]
+◆  v0.5.0  ‹2026-05-07›
+│  commit   pr    title                         closes            type / filter reason
+│
+●  a1b2c3d  #466  feat: multi-output formats    #450, #451, #452  enhancement
+│
+·  deadbee  —   chore: fix typo in README                       filtered: no PR
+│
+·  f7e8d9c  #467  chore: update CI config                         filtered: label:chore
+│
+●  1234567  #470  fix: nil deref in summarizer  #468              bug
+│
+◆  v0.4.1  ‹2026-04-18›
+
+---
+
+[TestEncoder_Encode/expanded,_hide-filtered,_with_previous_release - 1]
+◆  v0.5.0  ‹2026-05-07›
+│  commit   pr    title                             type / filter reason
+│
+●  a1b2c3d  #466  feat: multi-output formats        enhancement
+│                 closes #450  add JSON output to releases       enhancement
+│                 closes #451  document the JSON schema          enhancement
+│
+●  1234567  #470  fix: nil deref in summarizer      bug
+│                 closes #468  panic on empty merge commit list  bug
+│
+◆  v0.4.1  ‹2026-04-18›
+
+---
+
+[TestEncoder_Encode/expanded,_show-filtered,_with_previous_release - 1]
+◆  v0.5.0  ‹2026-05-07›
+│  commit   pr    title                                         type / filter reason
+│
+●  a1b2c3d  #466  feat: multi-output formats                    enhancement
+│                 closes #450  add JSON output to releases                   enhancement
+│                 closes #451  document the JSON schema                      enhancement
+│                 closes #452  stale issue that was closed but not in scope  filtered: out-of-scope
+│
+·  deadbee  —   chore: fix typo in README                     filtered: no PR
+│
+·  f7e8d9c  #467  chore: update CI config                       filtered: label:chore
+│
+●  1234567  #470  fix: nil deref in summarizer                  bug
+│                 closes #468  panic on empty merge commit list              bug
+│
+◆  v0.4.1  ‹2026-04-18›
+
+---
+
+[TestEncoder_Encode/condensed,_no_previous_release_(no_bottom_anchor) - 1]
+◆  v0.5.0  ‹2026-05-07›
+│  commit   pr    title                         closes      type / filter reason
+│
+●  a1b2c3d  #466  feat: multi-output formats    #450, #451  enhancement
+│
+●  1234567  #470  fix: nil deref in summarizer  #468        bug
+
+---
+
+[TestEncoder_Encode/condensed,_speculated_release_(open_diamond_+_parenthetical) - 1]
+◇  v0.5.0  ‹2026-05-07 (speculated)›
+│  commit   pr    title                         closes      type / filter reason
+│
+●  a1b2c3d  #466  feat: multi-output formats    #450, #451  enhancement
+│
+●  1234567  #470  fix: nil deref in summarizer  #468        bug
+│
+◆  v0.4.1  ‹2026-04-18›
+
+---
+
+[TestEncoder_Encode/non-TTY_output_contains_no_ANSI_escapes - 1]
+◆  v0.5.0  ‹2026-05-07›
+│  commit   pr    title                         closes            type / filter reason
+│
+●  a1b2c3d  #466  feat: multi-output formats    #450, #451, #452  enhancement
+│
+·  deadbee  —   chore: fix typo in README                       filtered: no PR
+│
+·  f7e8d9c  #467  chore: update CI config                         filtered: label:chore
+│
+●  1234567  #470  fix: nil deref in summarizer  #468              bug
+│
+◆  v0.4.1  ‹2026-04-18›
+
+---

--- a/chronicle/release/output/encoders/trunk/__snapshots__/encoder_test.snap
+++ b/chronicle/release/output/encoders/trunk/__snapshots__/encoder_test.snap
@@ -17,7 +17,7 @@
 │
 ●  a1b2c3d  #466  feat: multi-output formats    #450, #451, #452  enhancement
 │
-·  deadbee  —   chore: fix typo in README                       filtered: no PR
+·  deadbee  —     chore: fix typo in README                       filtered: no PR
 │
 ·  f7e8d9c  #467  chore: update CI config                         filtered: label:chore
 │
@@ -51,7 +51,7 @@
 │                 closes #451  document the JSON schema                      enhancement
 │                 closes #452  stale issue that was closed but not in scope  filtered: out-of-scope
 │
-·  deadbee  —   chore: fix typo in README                     filtered: no PR
+·  deadbee  —     chore: fix typo in README                     filtered: no PR
 │
 ·  f7e8d9c  #467  chore: update CI config                       filtered: label:chore
 │
@@ -90,7 +90,7 @@
 │
 ●  a1b2c3d  #466  feat: multi-output formats    #450, #451, #452  enhancement
 │
-·  deadbee  —   chore: fix typo in README                       filtered: no PR
+·  deadbee  —     chore: fix typo in README                       filtered: no PR
 │
 ·  f7e8d9c  #467  chore: update CI config                         filtered: label:chore
 │

--- a/chronicle/release/output/encoders/trunk/condensed.go
+++ b/chronicle/release/output/encoders/trunk/condensed.go
@@ -1,0 +1,213 @@
+package trunk
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/anchore/chronicle/chronicle/release"
+	"github.com/anchore/chronicle/chronicle/release/change"
+)
+
+// maxTitleWidth caps auto-sized title columns so very long PR titles don't
+// produce unwieldy line lengths.
+const maxTitleWidth = 80
+
+// renderCondensed writes one row per commit between the top and bottom anchors.
+// Issues are collapsed into the "closes" column on the same row as their PR.
+func (e *Encoder) renderCondensed(w io.Writer, d release.Description) error {
+	st := newStyles(e.IsTTY)
+
+	rows := e.buildCondensedRows(d)
+	wHash, wPR, wTitle, wCloses := measureCondensedColumns(rows)
+
+	// header row sits on top of the trunk line. Putting "│" at column 0 keeps
+	// the trunk visually continuous from anchor → header → data rows.
+	header := fmt.Sprintf("%s  %-*s  %-*s  %-*s  %-*s  %s",
+		st.trunkLine,
+		wHash, "commit",
+		wPR, "pr",
+		wTitle, "title",
+		wCloses, "closes",
+		"type / filter reason",
+	)
+
+	if err := writeTopAnchor(w, d, st); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintln(w, st.dim.Render(header)); err != nil {
+		return err
+	}
+
+	// second pass: write rows.
+	for _, r := range rows {
+		if _, err := fmt.Fprintln(w, st.dim.Render(st.trunkLine)); err != nil {
+			return err
+		}
+
+		title := r.title
+		if len(title) > wTitle {
+			title = title[:wTitle]
+		}
+
+		if err := writeCondensedRow(w, st, r, title, wHash, wPR, wTitle, wCloses); err != nil {
+			return err
+		}
+	}
+
+	if d.PreviousRelease != nil {
+		if _, err := fmt.Fprintln(w, st.dim.Render(st.trunkLine)); err != nil {
+			return err
+		}
+		if err := writeBottomAnchor(w, d.PreviousRelease, st); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// measureCondensedColumns scans rows to find the widths needed for each column,
+// floored by the header label widths and capped by maxTitleWidth for the title.
+// Widths are based on visible (printable) content — escape codes for hyperlinks
+// or styling are added later, so they must not affect column sizing.
+func measureCondensedColumns(rows []condensedRow) (wHash, wPR, wTitle, wCloses int) {
+	wHash = len("commit")
+	wPR = len("pr")
+	wTitle = len("title")
+	wCloses = len("closes")
+	for _, r := range rows {
+		if l := len(r.hash); l > wHash {
+			wHash = l
+		}
+		if l := len(r.pr); l > wPR {
+			wPR = l
+		}
+		if l := len(r.title); l > wTitle {
+			wTitle = l
+		}
+		if l := closeRefsVisibleWidth(r.closes); l > wCloses {
+			wCloses = l
+		}
+	}
+	if wTitle > maxTitleWidth {
+		wTitle = maxTitleWidth
+	}
+	return
+}
+
+// writeCondensedRow renders one commit row with the glyph and type column
+// colored by the row's semver category. Filtered rows render entirely dim,
+// overriding the category color so the dim/normal distinction stays primary.
+// Hash, PR#, and each issue ref in the closes column are wrapped with OSC 8
+// hyperlinks when the destination is a TTY and a URL is available.
+func writeCondensedRow(w io.Writer, st styles, r condensedRow, title string, wHash, wPR, wTitle, wCloses int) error {
+	var glyphStyle, typeStyle, restStyle = st.normal, st.normal, st.normal
+
+	switch {
+	case r.filtered:
+		glyphStyle = st.dim
+		typeStyle = st.dim
+		restStyle = st.dim
+	default:
+		cat := st.styleForKind(r.kind)
+		glyphStyle = cat
+		typeStyle = cat
+	}
+
+	hashCell := padToVisibleWidth(st.link(r.hash, r.hashURL), len(r.hash), wHash)
+	prCell := padToVisibleWidth(st.link(r.pr, r.prURL), len(r.pr), wPR)
+	closesCell := padToVisibleWidth(renderCloseRefs(st, r.closes), closeRefsVisibleWidth(r.closes), wCloses)
+
+	mid := fmt.Sprintf("  %s  %s  %-*s  %s  ",
+		hashCell,
+		prCell,
+		wTitle, title,
+		closesCell,
+	)
+
+	line := glyphStyle.Render(r.glyph) + restStyle.Render(mid) + typeStyle.Render(r.typ)
+	_, err := fmt.Fprintln(w, line)
+	return err
+}
+
+// condensedRow holds the pre-formatted strings for a single condensed commit row.
+type condensedRow struct {
+	glyph    string
+	hash     string
+	hashURL  string
+	pr       string
+	prURL    string
+	title    string
+	closes   []closeRef
+	typ      string
+	filtered bool
+	kind     change.SemVerKind
+}
+
+// buildCondensedRows returns the rows that should be rendered, already formatted,
+// respecting ShowFiltered.
+func (e *Encoder) buildCondensedRows(d release.Description) []condensedRow {
+	var rows []condensedRow
+	for _, c := range d.Trunk.Commits {
+		filtered := c.PR == nil || c.PR.Filtered
+
+		if filtered && !e.ShowFiltered {
+			continue
+		}
+
+		var (
+			hash    = shortHash(c.Hash)
+			hashURL = c.URL
+			prNum   = "—"
+			prURL   string
+			title   = c.Subject
+			closes  []closeRef
+			typ     string
+			glyph   string
+			kind    change.SemVerKind
+		)
+
+		if filtered {
+			glyph = "·"
+			if c.PR != nil {
+				prNum = fmt.Sprintf("#%d", c.PR.Number)
+				prURL = c.PR.URL
+				title = c.PR.Title
+				typ = "filtered: " + c.PR.Reason
+			} else {
+				typ = "filtered: no PR"
+			}
+		} else {
+			glyph = "●"
+			prNum = fmt.Sprintf("#%d", c.PR.Number)
+			prURL = c.PR.URL
+			title = c.PR.Title
+			typ = joinChangeTypes(c.PR.ChangeTypes)
+			kind = highestKind(c.PR.ChangeTypes)
+
+			for _, iss := range c.PR.Issues {
+				if !iss.Filtered || e.ShowFiltered {
+					closes = append(closes, closeRef{
+						text: fmt.Sprintf("#%d", iss.Number),
+						url:  iss.URL,
+					})
+				}
+			}
+		}
+
+		rows = append(rows, condensedRow{
+			glyph:    glyph,
+			hash:     hash,
+			hashURL:  hashURL,
+			pr:       prNum,
+			prURL:    prURL,
+			title:    title,
+			closes:   closes,
+			typ:      typ,
+			filtered: filtered,
+			kind:     kind,
+		})
+	}
+	return rows
+}

--- a/chronicle/release/output/encoders/trunk/condensed.go
+++ b/chronicle/release/output/encoders/trunk/condensed.go
@@ -45,10 +45,7 @@ func (e *Encoder) renderCondensed(w io.Writer, d release.Description) error {
 			return err
 		}
 
-		title := r.title
-		if len(title) > wTitle {
-			title = title[:wTitle]
-		}
+		title := truncateRunes(r.title, wTitle)
 
 		if err := writeCondensedRow(w, st, r, title, wHash, wPR, wTitle, wCloses); err != nil {
 			return err
@@ -69,21 +66,21 @@ func (e *Encoder) renderCondensed(w io.Writer, d release.Description) error {
 
 // measureCondensedColumns scans rows to find the widths needed for each column,
 // floored by the header label widths and capped by maxTitleWidth for the title.
-// Widths are based on visible (printable) content — escape codes for hyperlinks
-// or styling are added later, so they must not affect column sizing.
+// Widths are based on visible (rune-count) content — escape codes for hyperlinks
+// or styling are added later and must not affect column sizing.
 func measureCondensedColumns(rows []condensedRow) (wHash, wPR, wTitle, wCloses int) {
 	wHash = len("commit")
 	wPR = len("pr")
 	wTitle = len("title")
 	wCloses = len("closes")
 	for _, r := range rows {
-		if l := len(r.hash); l > wHash {
+		if l := visibleLen(r.hash); l > wHash {
 			wHash = l
 		}
-		if l := len(r.pr); l > wPR {
+		if l := visibleLen(r.pr); l > wPR {
 			wPR = l
 		}
-		if l := len(r.title); l > wTitle {
+		if l := visibleLen(r.title); l > wTitle {
 			wTitle = l
 		}
 		if l := closeRefsVisibleWidth(r.closes); l > wCloses {
@@ -100,7 +97,9 @@ func measureCondensedColumns(rows []condensedRow) (wHash, wPR, wTitle, wCloses i
 // colored by the row's semver category. Filtered rows render entirely dim,
 // overriding the category color so the dim/normal distinction stays primary.
 // Hash, PR#, and each issue ref in the closes column are wrapped with OSC 8
-// hyperlinks when the destination is a TTY and a URL is available.
+// hyperlinks when the destination is a TTY and a URL is available. Cell
+// styling is applied INSIDE each hyperlink wrap so dim/color attributes
+// survive terminals that reset SGR state at OSC 8 boundaries.
 func writeCondensedRow(w io.Writer, st styles, r condensedRow, title string, wHash, wPR, wTitle, wCloses int) error {
 	var glyphStyle, typeStyle, restStyle = st.normal, st.normal, st.normal
 
@@ -115,18 +114,19 @@ func writeCondensedRow(w io.Writer, st styles, r condensedRow, title string, wHa
 		typeStyle = cat
 	}
 
-	hashCell := padToVisibleWidth(st.link(r.hash, r.hashURL), len(r.hash), wHash)
-	prCell := padToVisibleWidth(st.link(r.pr, r.prURL), len(r.pr), wPR)
-	closesCell := padToVisibleWidth(renderCloseRefs(st, r.closes), closeRefsVisibleWidth(r.closes), wCloses)
+	hashCell := padToVisibleWidth(st.styledLink(r.hash, r.hashURL, restStyle), visibleLen(r.hash), wHash)
+	prCell := padToVisibleWidth(st.styledLink(r.pr, r.prURL, restStyle), visibleLen(r.pr), wPR)
+	closesCell := padToVisibleWidth(renderCloseRefs(st, r.closes, restStyle), closeRefsVisibleWidth(r.closes), wCloses)
+	titleCell := padToVisibleWidth(restStyle.Render(title), visibleLen(title), wTitle)
 
-	mid := fmt.Sprintf("  %s  %s  %-*s  %s  ",
+	mid := fmt.Sprintf("  %s  %s  %s  %s  ",
 		hashCell,
 		prCell,
-		wTitle, title,
+		titleCell,
 		closesCell,
 	)
 
-	line := glyphStyle.Render(r.glyph) + restStyle.Render(mid) + typeStyle.Render(r.typ)
+	line := glyphStyle.Render(r.glyph) + mid + typeStyle.Render(r.typ)
 	_, err := fmt.Fprintln(w, line)
 	return err
 }

--- a/chronicle/release/output/encoders/trunk/encoder.go
+++ b/chronicle/release/output/encoders/trunk/encoder.go
@@ -1,0 +1,44 @@
+// Package trunk provides a commit-anchored vertical-trunk visualization of a release.
+// It renders commits newest-first between version anchors, showing PR numbers, titles,
+// linked issues, and change types. Two display modes are available: condensed (one row
+// per commit) and expanded (issues get their own indented rows beneath their PR).
+package trunk
+
+import (
+	"errors"
+	"io"
+
+	"github.com/anchore/chronicle/chronicle/release"
+)
+
+// ID is the registered name for this encoder.
+const ID = "trunk"
+
+// Encoder renders a trunk-style commit visualization.
+//
+// Condensed=true collapses issues into the "closes" column of each commit row.
+// Condensed=false (expanded) gives each issue its own indented row.
+// ShowFiltered=true renders filtered rows in a dim style; false omits them.
+// IsTTY controls whether ANSI escape codes are emitted.
+type Encoder struct {
+	Condensed    bool
+	ShowFiltered bool
+	IsTTY        bool
+}
+
+func (e *Encoder) ID() string { return ID }
+
+// Encode writes the trunk visualization to w. The title parameter is ignored
+// because version anchors embed the version and date instead.
+func (e *Encoder) Encode(w io.Writer, _ string, d release.Description) error {
+	if d.Trunk == nil {
+		return errors.New(`the "trunk" output format requires commits in scope; enable "consider-pr-merge-commits" in your config`)
+	}
+	if len(d.Trunk.Commits) == 0 {
+		return errors.New(`the "trunk" output format requires commits in scope; enable "consider-pr-merge-commits" in your config`)
+	}
+	if e.Condensed {
+		return e.renderCondensed(w, d)
+	}
+	return e.renderExpanded(w, d)
+}

--- a/chronicle/release/output/encoders/trunk/encoder_test.go
+++ b/chronicle/release/output/encoders/trunk/encoder_test.go
@@ -283,3 +283,58 @@ func TestEncoder_Hyperlinks(t *testing.T) {
 		require.Contains(t, buf.String(), osc8+"https://github.com/owner/repo/issues/450")
 	})
 }
+
+// TestEncoder_FilteredRowsFullyDim verifies that on a TTY, every cell in a
+// filtered row (hash, PR#, title, type) is wrapped in the dim SGR sequence.
+// Previously the outer wrap was applied around the joined row, which could lose
+// the dim attribute across OSC 8 hyperlink boundaries — leaving PR# and title
+// rendered at normal brightness.
+func TestEncoder_FilteredRowsFullyDim(t *testing.T) {
+	td := &release.TrunkData{
+		Commits: []release.TrunkCommit{
+			{
+				// kept commit so the rendered output has at least one visible row.
+				Hash:    "a1b2c3d4e5f6abc",
+				URL:     "https://github.com/owner/repo/commit/a1b2c3d4e5f6abc",
+				Subject: "feat: kept",
+				PR: &release.TrunkPR{
+					Number: 100, Title: "feat: kept", URL: "https://github.com/owner/repo/pull/100",
+					ChangeTypes: []change.Type{change.NewType("enhancement", change.SemVerMinor)},
+				},
+			},
+			{
+				// filtered commit with a PR that didn't make the changelog.
+				Hash:    "deadbeefcafe000",
+				URL:     "https://github.com/owner/repo/commit/deadbeefcafe000",
+				Subject: "chore: skip me",
+				PR: &release.TrunkPR{
+					Number:   999,
+					Title:    "chore: this PR was filtered",
+					URL:      "https://github.com/owner/repo/pull/999",
+					Filtered: true,
+					Reason:   "label:chore",
+				},
+			},
+		},
+	}
+	desc := fixtureDescription(false, fixturePreviousRelease, td)
+
+	var buf bytes.Buffer
+	require.NoError(t, (&Encoder{Condensed: true, ShowFiltered: true, IsTTY: true}).Encode(&buf, "", desc))
+	out := buf.String()
+
+	const dim = "\x1b[2m"
+
+	// each visible piece of the filtered row must be wrapped by a dim SGR open code.
+	// the visible chars themselves must follow a dim opener somewhere in the output.
+	for _, fragment := range []string{"deadbee", "#999", "chore: this PR was filtered", "filtered: label:chore"} {
+		idx := strings.Index(out, fragment)
+		require.NotEqual(t, -1, idx, "expected fragment %q in output", fragment)
+		// scan backward from the fragment to confirm a dim SGR opener appears
+		// before any reset / non-dim SGR; the simplest check is that the substring
+		// starting from the most recent dim opener still contains the fragment.
+		head := out[:idx]
+		dimAt := strings.LastIndex(head, dim)
+		require.NotEqual(t, -1, dimAt, "fragment %q is not preceded by a dim SGR opener", fragment)
+	}
+}

--- a/chronicle/release/output/encoders/trunk/encoder_test.go
+++ b/chronicle/release/output/encoders/trunk/encoder_test.go
@@ -1,0 +1,285 @@
+package trunk
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/chronicle/chronicle/release"
+	"github.com/anchore/chronicle/chronicle/release/change"
+)
+
+// fixtureRelease is the current release used across all snapshot tests.
+var fixtureRelease = release.Release{
+	Version: "v0.5.0",
+	Date:    time.Date(2026, time.May, 7, 0, 0, 0, 0, time.UTC),
+}
+
+// fixturePreviousRelease is the prior release anchor.
+var fixturePreviousRelease = &release.Release{
+	Version: "v0.4.1",
+	Date:    time.Date(2026, time.April, 18, 0, 0, 0, 0, time.UTC),
+}
+
+// fixtureTrunkData is a small but representative TrunkData covering:
+//   - a kept commit with a PR, two kept issues, and one filtered issue
+//   - a filtered commit (no-PR case)
+//   - a filtered commit (PR exists but is filtered)
+//   - a kept commit with a PR and no issues
+var fixtureTrunkData = &release.TrunkData{
+	Commits: []release.TrunkCommit{
+		{
+			Hash:    "a1b2c3d4e5f6abc",
+			Subject: "Merge pull request #466 from user/feature",
+			PR: &release.TrunkPR{
+				Number: 466,
+				Title:  "feat: multi-output formats",
+				ChangeTypes: []change.Type{
+					change.NewType("enhancement", change.SemVerMinor),
+				},
+				Issues: []release.TrunkIssue{
+					{
+						Number: 450,
+						Title:  "add JSON output to releases",
+						ChangeTypes: []change.Type{
+							change.NewType("enhancement", change.SemVerMinor),
+						},
+					},
+					{
+						Number: 451,
+						Title:  "document the JSON schema",
+						ChangeTypes: []change.Type{
+							change.NewType("enhancement", change.SemVerMinor),
+						},
+					},
+					{
+						Number:   452,
+						Title:    "stale issue that was closed but not in scope",
+						Filtered: true,
+						Reason:   "out-of-scope",
+					},
+				},
+			},
+		},
+		{
+			// commit with no PR — always filtered.
+			Hash:    "deadbeefcafe000",
+			Subject: "chore: fix typo in README",
+		},
+		{
+			Hash:    "f7e8d9c0b1a2345",
+			Subject: "Merge pull request #467 from user/chore",
+			PR: &release.TrunkPR{
+				Number:   467,
+				Title:    "chore: update CI config",
+				Filtered: true,
+				Reason:   "label:chore",
+			},
+		},
+		{
+			Hash:    "1234567890abcde",
+			Subject: "Merge pull request #470 from user/bugfix",
+			PR: &release.TrunkPR{
+				Number: 470,
+				Title:  "fix: nil deref in summarizer",
+				ChangeTypes: []change.Type{
+					change.NewType("bug", change.SemVerPatch),
+				},
+				Issues: []release.TrunkIssue{
+					{
+						Number: 468,
+						Title:  "panic on empty merge commit list",
+						ChangeTypes: []change.Type{
+							change.NewType("bug", change.SemVerPatch),
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+// fixtureDescription builds a full Description from the fixture data.
+func fixtureDescription(speculated bool, prevRelease *release.Release, trunk *release.TrunkData) release.Description {
+	return release.Description{
+		Release:         fixtureRelease,
+		PreviousRelease: prevRelease,
+		Speculated:      speculated,
+		Trunk:           trunk,
+	}
+}
+
+func TestEncoder_Encode(t *testing.T) {
+	tests := []struct {
+		name    string
+		encoder Encoder
+		desc    release.Description
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "condensed, hide-filtered, with previous release",
+			encoder: Encoder{
+				Condensed:    true,
+				ShowFiltered: false,
+				IsTTY:        false,
+			},
+			desc: fixtureDescription(false, fixturePreviousRelease, fixtureTrunkData),
+		},
+		{
+			name: "condensed, show-filtered, with previous release",
+			encoder: Encoder{
+				Condensed:    true,
+				ShowFiltered: true,
+				IsTTY:        false,
+			},
+			desc: fixtureDescription(false, fixturePreviousRelease, fixtureTrunkData),
+		},
+		{
+			name: "expanded, hide-filtered, with previous release",
+			encoder: Encoder{
+				Condensed:    false,
+				ShowFiltered: false,
+				IsTTY:        false,
+			},
+			desc: fixtureDescription(false, fixturePreviousRelease, fixtureTrunkData),
+		},
+		{
+			name: "expanded, show-filtered, with previous release",
+			encoder: Encoder{
+				Condensed:    false,
+				ShowFiltered: true,
+				IsTTY:        false,
+			},
+			desc: fixtureDescription(false, fixturePreviousRelease, fixtureTrunkData),
+		},
+		{
+			name: "condensed, no previous release (no bottom anchor)",
+			encoder: Encoder{
+				Condensed:    true,
+				ShowFiltered: false,
+				IsTTY:        false,
+			},
+			desc: fixtureDescription(false, nil, fixtureTrunkData),
+		},
+		{
+			name: "condensed, speculated release (open diamond + parenthetical)",
+			encoder: Encoder{
+				Condensed:    true,
+				ShowFiltered: false,
+				IsTTY:        false,
+			},
+			desc: fixtureDescription(true, fixturePreviousRelease, fixtureTrunkData),
+		},
+		{
+			name: "non-TTY output contains no ANSI escapes",
+			encoder: Encoder{
+				Condensed:    true,
+				ShowFiltered: true,
+				IsTTY:        false,
+			},
+			desc: fixtureDescription(false, fixturePreviousRelease, fixtureTrunkData),
+		},
+		{
+			name: "nil trunk returns error",
+			encoder: Encoder{
+				Condensed: true,
+				IsTTY:     false,
+			},
+			desc:    fixtureDescription(false, fixturePreviousRelease, nil),
+			wantErr: require.Error,
+		},
+		{
+			name: "empty trunk commits returns error",
+			encoder: Encoder{
+				Condensed: true,
+				IsTTY:     false,
+			},
+			desc:    fixtureDescription(false, fixturePreviousRelease, &release.TrunkData{}),
+			wantErr: require.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
+			}
+
+			var buf bytes.Buffer
+			err := tt.encoder.Encode(&buf, "", tt.desc)
+			tt.wantErr(t, err)
+
+			if err != nil {
+				return
+			}
+
+			out := buf.String()
+
+			// for the non-TTY case, explicitly assert no ANSI escapes.
+			if tt.name == "non-TTY output contains no ANSI escapes" {
+				require.False(t, strings.Contains(out, "\x1b"), "output should not contain ANSI escape codes when IsTTY=false")
+			}
+
+			snaps.MatchSnapshot(t, out)
+		})
+	}
+}
+
+func TestEncoder_Hyperlinks(t *testing.T) {
+	// fixture with URLs populated on commit, PR, and issue.
+	withURLs := &release.TrunkData{
+		Commits: []release.TrunkCommit{
+			{
+				Hash:    "a1b2c3d4e5f6abc",
+				URL:     "https://github.com/owner/repo/commit/a1b2c3d4e5f6abc",
+				Subject: "feat: add thing",
+				PR: &release.TrunkPR{
+					Number: 466,
+					Title:  "feat: add thing",
+					URL:    "https://github.com/owner/repo/pull/466",
+					ChangeTypes: []change.Type{
+						change.NewType("enhancement", change.SemVerMinor),
+					},
+					Issues: []release.TrunkIssue{
+						{
+							Number: 450,
+							Title:  "request thing",
+							URL:    "https://github.com/owner/repo/issues/450",
+							ChangeTypes: []change.Type{
+								change.NewType("enhancement", change.SemVerMinor),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	desc := fixtureDescription(false, fixturePreviousRelease, withURLs)
+
+	const osc8 = "\x1b]8;;"
+
+	t.Run("TTY emits OSC 8 hyperlinks for commit, PR, and issue", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, (&Encoder{Condensed: true, ShowFiltered: false, IsTTY: true}).Encode(&buf, "", desc))
+		out := buf.String()
+		require.Contains(t, out, osc8+"https://github.com/owner/repo/commit/a1b2c3d4e5f6abc")
+		require.Contains(t, out, osc8+"https://github.com/owner/repo/pull/466")
+		require.Contains(t, out, osc8+"https://github.com/owner/repo/issues/450")
+	})
+
+	t.Run("non-TTY emits no hyperlink escapes", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, (&Encoder{Condensed: true, ShowFiltered: false, IsTTY: false}).Encode(&buf, "", desc))
+		require.NotContains(t, buf.String(), osc8)
+	})
+
+	t.Run("expanded TTY emits OSC 8 for issue ref under commit", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, (&Encoder{Condensed: false, ShowFiltered: false, IsTTY: true}).Encode(&buf, "", desc))
+		require.Contains(t, buf.String(), osc8+"https://github.com/owner/repo/issues/450")
+	})
+}

--- a/chronicle/release/output/encoders/trunk/expanded.go
+++ b/chronicle/release/output/encoders/trunk/expanded.go
@@ -47,10 +47,7 @@ func (e *Encoder) renderExpanded(w io.Writer, d release.Description) error {
 			return err
 		}
 
-		title := r.title
-		if len(title) > wTitle {
-			title = title[:wTitle]
-		}
+		title := truncateRunes(r.title, wTitle)
 
 		if err := writeExpandedCommitRow(w, st, r, title, wHash, wPR, wTitle); err != nil {
 			return err
@@ -71,21 +68,22 @@ func (e *Encoder) renderExpanded(w io.Writer, d release.Description) error {
 
 // measureExpandedColumns scans commit and issue rows to find per-column widths,
 // floored by the header label widths and capped by maxTitleWidth for the title.
+// Widths are based on visible (rune-count) content.
 func measureExpandedColumns(rows []expandedRow) (wHash, wPR, wTitle int) {
 	wHash = len("commit")
 	wPR = len("pr")
 	wTitle = len("title")
 	for _, r := range rows {
-		if l := len(r.title); l > wTitle {
+		if l := visibleLen(r.title); l > wTitle {
 			wTitle = l
 		}
 		if r.isIssue {
 			continue
 		}
-		if l := len(r.hash); l > wHash {
+		if l := visibleLen(r.hash); l > wHash {
 			wHash = l
 		}
-		if l := len(r.pr); l > wPR {
+		if l := visibleLen(r.pr); l > wPR {
 			wPR = l
 		}
 	}
@@ -97,7 +95,9 @@ func measureExpandedColumns(rows []expandedRow) (wHash, wPR, wTitle int) {
 
 // writeExpandedCommitRow renders a top-level commit row with categorical
 // coloring on the glyph and the type column. Hash and PR# are hyperlinked
-// when URLs are present.
+// when URLs are present. Cell styling is applied inside each hyperlink wrap
+// so dim attributes survive terminals that reset SGR state at OSC 8
+// boundaries.
 func writeExpandedCommitRow(w io.Writer, st styles, r expandedRow, title string, wHash, wPR, wTitle int) error {
 	var glyphStyle, typeStyle, restStyle = st.normal, st.normal, st.normal
 
@@ -111,16 +111,17 @@ func writeExpandedCommitRow(w io.Writer, st styles, r expandedRow, title string,
 		typeStyle = cat
 	}
 
-	hashCell := padToVisibleWidth(st.link(r.hash, r.hashURL), len(r.hash), wHash)
-	prCell := padToVisibleWidth(st.link(r.pr, r.prURL), len(r.pr), wPR)
+	hashCell := padToVisibleWidth(st.styledLink(r.hash, r.hashURL, restStyle), visibleLen(r.hash), wHash)
+	prCell := padToVisibleWidth(st.styledLink(r.pr, r.prURL, restStyle), visibleLen(r.pr), wPR)
+	titleCell := padToVisibleWidth(restStyle.Render(title), visibleLen(title), wTitle)
 
-	mid := fmt.Sprintf("  %s  %s  %-*s  ",
+	mid := fmt.Sprintf("  %s  %s  %s  ",
 		hashCell,
 		prCell,
-		wTitle, title,
+		titleCell,
 	)
 
-	line := glyphStyle.Render(r.glyph) + restStyle.Render(mid) + typeStyle.Render(r.typ)
+	line := glyphStyle.Render(r.glyph) + mid + typeStyle.Render(r.typ)
 	_, err := fmt.Fprintln(w, line)
 	return err
 }
@@ -131,10 +132,7 @@ func writeExpandedCommitRow(w io.Writer, st styles, r expandedRow, title string,
 // color (mirroring how the commit glyph carries the commit's category). The
 // trunk char at column 0 stays dim.
 func writeExpandedIssueRow(w io.Writer, st styles, r expandedRow, issuePrefix string, wTitle int) error {
-	issueTitle := r.title
-	if len(issueTitle) > wTitle {
-		issueTitle = issueTitle[:wTitle]
-	}
+	issueTitle := truncateRunes(r.title, wTitle)
 
 	var labelStyle, typeStyle, titleStyle = st.normal, st.normal, st.normal
 	if r.filtered {
@@ -148,16 +146,16 @@ func writeExpandedIssueRow(w io.Writer, st styles, r expandedRow, issuePrefix st
 	}
 
 	issueRef := fmt.Sprintf("#%d", r.issueNum)
-	linkedRef := st.link(issueRef, r.issueURL)
-	label := "closes " + linkedRef
+	linkedRef := st.styledLink(issueRef, r.issueURL, labelStyle)
+	label := labelStyle.Render("closes ") + linkedRef
 
 	// issuePrefix is "│" followed by spaces; render the trunk char dim so it
 	// matches the trunk decoration on the spacer lines.
 	prefix := st.dim.Render(st.trunkLine) + issuePrefix[len(st.trunkLine):]
 
-	mid := fmt.Sprintf("  %-*s  ", wTitle, issueTitle)
+	titleCell := padToVisibleWidth(titleStyle.Render(issueTitle), visibleLen(issueTitle), wTitle)
 
-	line := prefix + labelStyle.Render(label) + titleStyle.Render(mid) + typeStyle.Render(r.typ)
+	line := prefix + label + "  " + titleCell + "  " + typeStyle.Render(r.typ)
 	_, err := fmt.Fprintln(w, line)
 	return err
 }

--- a/chronicle/release/output/encoders/trunk/expanded.go
+++ b/chronicle/release/output/encoders/trunk/expanded.go
@@ -1,0 +1,285 @@
+package trunk
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/anchore/chronicle/chronicle/release"
+	"github.com/anchore/chronicle/chronicle/release/change"
+)
+
+// renderExpanded writes one row per commit plus additional indented rows for
+// each linked issue. The "closes" column is replaced by per-issue rows.
+func (e *Encoder) renderExpanded(w io.Writer, d release.Description) error {
+	st := newStyles(e.IsTTY)
+
+	rows := e.buildExpandedRows(d)
+	wHash, wPR, wTitle := measureExpandedColumns(rows)
+
+	issuePrefix := buildIssuePrefix(wHash, wPR)
+
+	// header row sits on the trunk line: "│" at col 0 keeps trunk continuous.
+	header := fmt.Sprintf("%s  %-*s  %-*s  %-*s  %s",
+		st.trunkLine,
+		wHash, "commit",
+		wPR, "pr",
+		wTitle, "title",
+		"type / filter reason",
+	)
+
+	if err := writeTopAnchor(w, d, st); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, st.dim.Render(header)); err != nil {
+		return err
+	}
+
+	for _, r := range rows {
+		if r.isIssue {
+			if err := writeExpandedIssueRow(w, st, r, issuePrefix, wTitle); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if _, err := fmt.Fprintln(w, st.dim.Render(st.trunkLine)); err != nil {
+			return err
+		}
+
+		title := r.title
+		if len(title) > wTitle {
+			title = title[:wTitle]
+		}
+
+		if err := writeExpandedCommitRow(w, st, r, title, wHash, wPR, wTitle); err != nil {
+			return err
+		}
+	}
+
+	if d.PreviousRelease != nil {
+		if _, err := fmt.Fprintln(w, st.dim.Render(st.trunkLine)); err != nil {
+			return err
+		}
+		if err := writeBottomAnchor(w, d.PreviousRelease, st); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// measureExpandedColumns scans commit and issue rows to find per-column widths,
+// floored by the header label widths and capped by maxTitleWidth for the title.
+func measureExpandedColumns(rows []expandedRow) (wHash, wPR, wTitle int) {
+	wHash = len("commit")
+	wPR = len("pr")
+	wTitle = len("title")
+	for _, r := range rows {
+		if l := len(r.title); l > wTitle {
+			wTitle = l
+		}
+		if r.isIssue {
+			continue
+		}
+		if l := len(r.hash); l > wHash {
+			wHash = l
+		}
+		if l := len(r.pr); l > wPR {
+			wPR = l
+		}
+	}
+	if wTitle > maxTitleWidth {
+		wTitle = maxTitleWidth
+	}
+	return
+}
+
+// writeExpandedCommitRow renders a top-level commit row with categorical
+// coloring on the glyph and the type column. Hash and PR# are hyperlinked
+// when URLs are present.
+func writeExpandedCommitRow(w io.Writer, st styles, r expandedRow, title string, wHash, wPR, wTitle int) error {
+	var glyphStyle, typeStyle, restStyle = st.normal, st.normal, st.normal
+
+	if r.filtered {
+		glyphStyle = st.dim
+		typeStyle = st.dim
+		restStyle = st.dim
+	} else {
+		cat := st.styleForKind(r.kind)
+		glyphStyle = cat
+		typeStyle = cat
+	}
+
+	hashCell := padToVisibleWidth(st.link(r.hash, r.hashURL), len(r.hash), wHash)
+	prCell := padToVisibleWidth(st.link(r.pr, r.prURL), len(r.pr), wPR)
+
+	mid := fmt.Sprintf("  %s  %s  %-*s  ",
+		hashCell,
+		prCell,
+		wTitle, title,
+	)
+
+	line := glyphStyle.Render(r.glyph) + restStyle.Render(mid) + typeStyle.Render(r.typ)
+	_, err := fmt.Fprintln(w, line)
+	return err
+}
+
+// writeExpandedIssueRow renders an indented "closes #N  title  type" row
+// under its parent commit. The #N is hyperlinked when the issue URL is set.
+// The "closes #N" prefix and the type column take the issue's categorical
+// color (mirroring how the commit glyph carries the commit's category). The
+// trunk char at column 0 stays dim.
+func writeExpandedIssueRow(w io.Writer, st styles, r expandedRow, issuePrefix string, wTitle int) error {
+	issueTitle := r.title
+	if len(issueTitle) > wTitle {
+		issueTitle = issueTitle[:wTitle]
+	}
+
+	var labelStyle, typeStyle, titleStyle = st.normal, st.normal, st.normal
+	if r.filtered {
+		labelStyle = st.dim
+		typeStyle = st.dim
+		titleStyle = st.dim
+	} else {
+		cat := st.styleForKind(r.kind)
+		labelStyle = cat
+		typeStyle = cat
+	}
+
+	issueRef := fmt.Sprintf("#%d", r.issueNum)
+	linkedRef := st.link(issueRef, r.issueURL)
+	label := "closes " + linkedRef
+
+	// issuePrefix is "│" followed by spaces; render the trunk char dim so it
+	// matches the trunk decoration on the spacer lines.
+	prefix := st.dim.Render(st.trunkLine) + issuePrefix[len(st.trunkLine):]
+
+	mid := fmt.Sprintf("  %-*s  ", wTitle, issueTitle)
+
+	line := prefix + labelStyle.Render(label) + titleStyle.Render(mid) + typeStyle.Render(r.typ)
+	_, err := fmt.Fprintln(w, line)
+	return err
+}
+
+// expandedRow is a single line in the expanded output — either a commit row or
+// an issue sub-row.
+type expandedRow struct {
+	// commit fields (only set when isIssue=false).
+	glyph    string
+	hash     string
+	hashURL  string
+	pr       string
+	prURL    string
+	title    string
+	typ      string
+	filtered bool
+	kind     change.SemVerKind
+	// issue sub-row fields (only set when isIssue=true).
+	isIssue  bool
+	issueNum int
+	issueURL string
+}
+
+// buildExpandedRows returns commit rows interleaved with issue sub-rows.
+func (e *Encoder) buildExpandedRows(d release.Description) []expandedRow {
+	var rows []expandedRow
+	for _, c := range d.Trunk.Commits {
+		filtered := c.PR == nil || c.PR.Filtered
+
+		if filtered && !e.ShowFiltered {
+			continue
+		}
+
+		rows = append(rows, buildExpandedCommitRow(c, filtered))
+
+		if filtered || c.PR == nil {
+			continue
+		}
+
+		rows = append(rows, e.buildExpandedIssueRows(c.PR.Issues)...)
+	}
+	return rows
+}
+
+// buildExpandedCommitRow constructs a single commit row, choosing fields based
+// on whether the commit is filtered (no PR or PR.Filtered) or kept.
+func buildExpandedCommitRow(c release.TrunkCommit, filtered bool) expandedRow {
+	var (
+		hash    = shortHash(c.Hash)
+		hashURL = c.URL
+		prNum   = "—"
+		prURL   string
+		title   = c.Subject
+		typ     string
+		glyph   string
+		kind    change.SemVerKind
+	)
+
+	if filtered {
+		glyph = "·"
+		if c.PR != nil {
+			prNum = fmt.Sprintf("#%d", c.PR.Number)
+			prURL = c.PR.URL
+			title = c.PR.Title
+			typ = "filtered: " + c.PR.Reason
+		} else {
+			typ = "filtered: no PR"
+		}
+	} else {
+		glyph = "●"
+		prNum = fmt.Sprintf("#%d", c.PR.Number)
+		prURL = c.PR.URL
+		title = c.PR.Title
+		typ = joinChangeTypes(c.PR.ChangeTypes)
+		kind = highestKind(c.PR.ChangeTypes)
+	}
+
+	return expandedRow{
+		glyph:    glyph,
+		hash:     hash,
+		hashURL:  hashURL,
+		pr:       prNum,
+		prURL:    prURL,
+		title:    title,
+		typ:      typ,
+		filtered: filtered,
+		kind:     kind,
+	}
+}
+
+// buildExpandedIssueRows constructs the indented issue sub-rows for a kept PR,
+// honoring ShowFiltered when issues are themselves filtered.
+func (e *Encoder) buildExpandedIssueRows(issues []release.TrunkIssue) []expandedRow {
+	var rows []expandedRow
+	for _, iss := range issues {
+		if iss.Filtered && !e.ShowFiltered {
+			continue
+		}
+
+		issTyp := joinChangeTypes(iss.ChangeTypes)
+		if iss.Filtered {
+			issTyp = "filtered: " + iss.Reason
+		}
+
+		rows = append(rows, expandedRow{
+			title:    iss.Title,
+			typ:      issTyp,
+			filtered: iss.Filtered,
+			kind:     highestKind(iss.ChangeTypes),
+			isIssue:  true,
+			issueNum: iss.Number,
+			issueURL: iss.URL,
+		})
+	}
+	return rows
+}
+
+// buildIssuePrefix constructs the left-margin string that places the issue
+// label directly under the title column. Layout: glyph(1) + sp(2) + hash(wHash)
+// + sp(2) + pr(wPR) + sp(2) = the offset at which the title column begins.
+// We use "│" as the leftmost char and spaces for the rest.
+func buildIssuePrefix(wHash, wPR int) string {
+	indent := 1 + 2 + wHash + 2 + wPR + 2
+	return "│" + strings.Repeat(" ", indent-1)
+}

--- a/chronicle/release/output/encoders/trunk/style.go
+++ b/chronicle/release/output/encoders/trunk/style.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
@@ -159,6 +160,24 @@ func padToVisibleWidth(content string, visibleWidth, targetWidth int) string {
 	return content + strings.Repeat(" ", targetWidth-visibleWidth)
 }
 
+// visibleLen returns the rune count of s, which is the visible cell width for
+// plain text using single-cell glyphs (no double-wide CJK, no emoji). This is
+// what we need for column padding because byte-len would over-count multi-byte
+// runes like the em-dash placeholder used for missing PR numbers.
+func visibleLen(s string) int {
+	return utf8.RuneCountInString(s)
+}
+
+// truncateRunes returns s clipped to at most maxRunes runes, byte-safe for
+// multi-byte UTF-8. Used to cap long titles without splitting a rune.
+func truncateRunes(s string, maxRunes int) string {
+	if utf8.RuneCountInString(s) <= maxRunes {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxRunes])
+}
+
 // closeRef is one entry in the closes column: the visible label (e.g. "#450")
 // and the URL it should link to.
 type closeRef struct {
@@ -173,21 +192,29 @@ func closeRefsVisibleWidth(refs []closeRef) int {
 	}
 	n := 0
 	for _, r := range refs {
-		n += len(r.text)
+		n += visibleLen(r.text)
 	}
-	n += (len(refs) - 1) * 2 // ", " separators
+	n += (len(refs) - 1) * 2 // ", " separators (always ASCII)
 	return n
 }
 
-// renderCloseRefs returns the comma-joined string with each label hyperlinked
-// (when its url is non-empty and the styles support links).
-func renderCloseRefs(st styles, refs []closeRef) string {
+// renderCloseRefs returns the comma-joined string with each label first styled
+// with textStyle (so dim/category color survives across OSC 8 boundaries) and
+// then wrapped with a hyperlink when its url is non-empty.
+func renderCloseRefs(st styles, refs []closeRef, textStyle lipgloss.Style) string {
 	if len(refs) == 0 {
 		return ""
 	}
 	parts := make([]string, len(refs))
 	for i, r := range refs {
-		parts[i] = st.link(r.text, r.url)
+		parts[i] = st.styledLink(r.text, r.url, textStyle)
 	}
-	return strings.Join(parts, ", ")
+	return strings.Join(parts, textStyle.Render(", "))
+}
+
+// styledLink applies textStyle to text and then wraps with a hyperlink (when
+// supported and url is non-empty). Styling goes inside the OSC 8 wrap so it
+// survives terminals that reset SGR state at hyperlink boundaries.
+func (s styles) styledLink(text, url string, textStyle lipgloss.Style) string {
+	return s.link(textStyle.Render(text), url)
 }

--- a/chronicle/release/output/encoders/trunk/style.go
+++ b/chronicle/release/output/encoders/trunk/style.go
@@ -1,0 +1,189 @@
+package trunk
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/savioxavier/termlink"
+
+	"github.com/anchore/chronicle/chronicle/release"
+	"github.com/anchore/chronicle/chronicle/release/change"
+)
+
+// styles groups all the lipgloss styles used by the trunk renderer.
+// They are constructed once per Encode call via newStyles so that the
+// renderer's color profile (TTY vs ASCII) is set correctly for the output.
+type styles struct {
+	dim    lipgloss.Style
+	normal lipgloss.Style
+	// semver category styles. unknown reuses dim.
+	major lipgloss.Style
+	minor lipgloss.Style
+	patch lipgloss.Style
+	// trunkLine is the vertical connector drawn between rows.
+	trunkLine string
+	// link wraps text in an OSC 8 hyperlink escape when the destination is a
+	// TTY and a non-empty URL is provided; otherwise it returns text unchanged.
+	link func(text, url string) string
+}
+
+// newStyles builds a styles value whose color profile matches isTTY.
+// When isTTY is false the renderer uses termenv.Ascii so all styles become no-ops
+// and no ANSI escape codes are emitted.
+func newStyles(isTTY bool) styles {
+	r := lipgloss.NewRenderer(nil)
+	if !isTTY {
+		r.SetColorProfile(termenv.Ascii)
+	}
+
+	link := func(text, _ string) string { return text }
+	if isTTY {
+		link = func(text, url string) string {
+			if url == "" {
+				return text
+			}
+			return termlink.Link(text, url)
+		}
+	}
+
+	return styles{
+		dim:    r.NewStyle().Faint(true),
+		normal: r.NewStyle(),
+		// 256-color palette indices that look reasonable on both light and dark
+		// terminal backgrounds. Major = red (breaking), minor = green (feature),
+		// patch = cyan (fix). Unknown falls through to dim.
+		major:     r.NewStyle().Foreground(lipgloss.Color("9")),
+		minor:     r.NewStyle().Foreground(lipgloss.Color("10")),
+		patch:     r.NewStyle().Foreground(lipgloss.Color("14")),
+		trunkLine: "│",
+		link:      link,
+	}
+}
+
+// styleForKind returns the foreground style for a semver category.
+// Unknown returns the dim style so unknown types render grey.
+func (s styles) styleForKind(k change.SemVerKind) lipgloss.Style {
+	switch k {
+	case change.SemVerMajor:
+		return s.major
+	case change.SemVerMinor:
+		return s.minor
+	case change.SemVerPatch:
+		return s.patch
+	}
+	return s.dim
+}
+
+// highestKind returns the most significant semver kind across the given
+// change types. Used to pick a single color per row when there are multiple
+// types attached.
+func highestKind(types []change.Type) change.SemVerKind {
+	out := change.SemVerUnknown
+	for _, t := range types {
+		if t.Kind > out {
+			out = t.Kind
+		}
+	}
+	return out
+}
+
+// writeTopAnchor writes the top version anchor line.
+// Uses ◇ (open diamond) when speculated, ◆ (filled diamond) otherwise.
+// The date (and optional "(speculated)") is rendered dim.
+func writeTopAnchor(w io.Writer, d release.Description, st styles) error {
+	glyph := "◆"
+	if d.Speculated {
+		glyph = "◇"
+	}
+
+	date := d.Date.Format("2006-01-02")
+	dateText := date
+	if d.Speculated {
+		dateText = date + " (speculated)"
+	}
+
+	line := fmt.Sprintf("%s  %s  %s",
+		glyph,
+		d.Version,
+		st.dim.Render("‹"+dateText+"›"),
+	)
+	_, err := fmt.Fprintln(w, line)
+	return err
+}
+
+// writeBottomAnchor writes the bottom version anchor for PreviousRelease.
+// The previous release is always a real tag so we always use ◆.
+func writeBottomAnchor(w io.Writer, prev *release.Release, st styles) error {
+	date := prev.Date.Format("2006-01-02")
+	line := fmt.Sprintf("%s  %s  %s",
+		"◆",
+		prev.Version,
+		st.dim.Render("‹"+date+"›"),
+	)
+	_, err := fmt.Fprintln(w, line)
+	return err
+}
+
+// shortHash returns the first 7 characters of a commit hash.
+func shortHash(hash string) string {
+	if len(hash) <= 7 {
+		return hash
+	}
+	return hash[:7]
+}
+
+// joinChangeTypes returns a comma-joined list of change type names.
+func joinChangeTypes(types []change.Type) string {
+	names := make([]string, 0, len(types))
+	for _, t := range types {
+		names = append(names, t.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
+// padToVisibleWidth pads content with trailing spaces so that the *visible*
+// (non-escape-code) width totals targetWidth. visibleWidth is the caller-known
+// printed width of content; this is needed because content may contain OSC 8
+// or SGR escape sequences that don't print but do increase len().
+func padToVisibleWidth(content string, visibleWidth, targetWidth int) string {
+	if visibleWidth >= targetWidth {
+		return content
+	}
+	return content + strings.Repeat(" ", targetWidth-visibleWidth)
+}
+
+// closeRef is one entry in the closes column: the visible label (e.g. "#450")
+// and the URL it should link to.
+type closeRef struct {
+	text string
+	url  string
+}
+
+// closeRefsVisibleWidth returns the visible width of the comma-joined refs.
+func closeRefsVisibleWidth(refs []closeRef) int {
+	if len(refs) == 0 {
+		return 0
+	}
+	n := 0
+	for _, r := range refs {
+		n += len(r.text)
+	}
+	n += (len(refs) - 1) * 2 // ", " separators
+	return n
+}
+
+// renderCloseRefs returns the comma-joined string with each label hyperlinked
+// (when its url is non-empty and the styles support links).
+func renderCloseRefs(st styles, refs []closeRef) string {
+	if len(refs) == 0 {
+		return ""
+	}
+	parts := make([]string, len(refs))
+	for i, r := range refs {
+		parts[i] = st.link(r.text, r.url)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/chronicle/release/output/encoders/trunk/style.go
+++ b/chronicle/release/output/encoders/trunk/style.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
-	"github.com/savioxavier/termlink"
 
 	"github.com/anchore/chronicle/chronicle/release"
 	"github.com/anchore/chronicle/chronicle/release/change"
@@ -45,7 +44,12 @@ func newStyles(isTTY bool) styles {
 			if url == "" {
 				return text
 			}
-			return termlink.Link(text, url)
+			// OSC 8 hyperlink: ESC ] 8 ; ; URL ESC \ TEXT ESC ] 8 ; ; ESC \
+			// Terminals that don't support OSC 8 ignore the unknown sequence and
+			// just print the visible text. We bypass termlink's environment-based
+			// detection because IsTTY is already the authority on whether we're
+			// writing to a terminal.
+			return "\x1b]8;;" + url + "\x1b\\" + text + "\x1b]8;;\x1b\\"
 		}
 	}
 

--- a/chronicle/release/output/encoders/trunk/style.go
+++ b/chronicle/release/output/encoders/trunk/style.go
@@ -32,10 +32,14 @@ type styles struct {
 
 // newStyles builds a styles value whose color profile matches isTTY.
 // When isTTY is false the renderer uses termenv.Ascii so all styles become no-ops
-// and no ANSI escape codes are emitted.
+// and no ANSI escape codes are emitted. When isTTY is true we explicitly force
+// ANSI256 — relying on lipgloss/termenv auto-detection would otherwise fall back
+// to Ascii in environments without a real stdout TTY (e.g., test runners).
 func newStyles(isTTY bool) styles {
 	r := lipgloss.NewRenderer(nil)
-	if !isTTY {
+	if isTTY {
+		r.SetColorProfile(termenv.ANSI256)
+	} else {
 		r.SetColorProfile(termenv.Ascii)
 	}
 

--- a/chronicle/release/releasers/github/gh_issue.go
+++ b/chronicle/release/releasers/github/gh_issue.go
@@ -24,7 +24,9 @@ type ghIssue struct {
 	URL        string
 }
 
-type issueFilter func(issue ghIssue) bool
+// issueFilter decides whether to keep an issue. When returning false, the optional
+// ctx pointer (if non-nil) is populated with a short reason identifier.
+type issueFilter func(issue ghIssue, ctx ...*string) bool
 
 func filterIssues(issues []ghIssue, filters ...issueFilter) []ghIssue {
 	if len(filters) == 0 {
@@ -48,9 +50,10 @@ issueLoop:
 
 //nolint:unused
 func issuesAtOrAfter(since time.Time) issueFilter {
-	return func(issue ghIssue) bool {
+	return func(issue ghIssue, ctx ...*string) bool {
 		keep := issue.ClosedAt.After(since) || issue.ClosedAt.Equal(since)
 		if !keep {
+			setIssueReason(ctx, "chronology:before-since")
 			log.Tracef("issue #%d filtered out: closed at or before %s (closed %s)", issue.Number, internal.FormatDateTime(since), internal.FormatDateTime(issue.ClosedAt))
 		}
 		return keep
@@ -58,9 +61,10 @@ func issuesAtOrAfter(since time.Time) issueFilter {
 }
 
 func issuesAtOrBefore(since time.Time) issueFilter {
-	return func(issue ghIssue) bool {
+	return func(issue ghIssue, ctx ...*string) bool {
 		keep := issue.ClosedAt.Before(since) || issue.ClosedAt.Equal(since)
 		if !keep {
+			setIssueReason(ctx, "chronology:after-until")
 			log.Tracef("issue #%d filtered out: closed at or after %s (closed %s)", issue.Number, internal.FormatDateTime(since), internal.FormatDateTime(issue.ClosedAt))
 		}
 		return keep
@@ -68,9 +72,10 @@ func issuesAtOrBefore(since time.Time) issueFilter {
 }
 
 func issuesAfter(since time.Time) issueFilter {
-	return func(issue ghIssue) bool {
+	return func(issue ghIssue, ctx ...*string) bool {
 		keep := issue.ClosedAt.After(since)
 		if !keep {
+			setIssueReason(ctx, "chronology:before-since")
 			log.Tracef("issue #%d filtered out: closed before %s (closed %s)", issue.Number, internal.FormatDateTime(since), internal.FormatDateTime(issue.ClosedAt))
 		}
 		return keep
@@ -79,9 +84,10 @@ func issuesAfter(since time.Time) issueFilter {
 
 //nolint:unused
 func issuesBefore(since time.Time) issueFilter {
-	return func(issue ghIssue) bool {
+	return func(issue ghIssue, ctx ...*string) bool {
 		keep := issue.ClosedAt.Before(since)
 		if !keep {
+			setIssueReason(ctx, "chronology:after-until")
 			log.Tracef("issue #%d filtered out: closed after %s (closed %s)", issue.Number, internal.FormatDateTime(since), internal.FormatDateTime(issue.ClosedAt))
 		}
 		return keep
@@ -89,7 +95,7 @@ func issuesBefore(since time.Time) issueFilter {
 }
 
 func issuesWithLabel(labels ...string) issueFilter {
-	return func(issue ghIssue) bool {
+	return func(issue ghIssue, ctx ...*string) bool {
 		for _, targetLabel := range labels {
 			for _, l := range issue.Labels {
 				if l == targetLabel {
@@ -98,6 +104,7 @@ func issuesWithLabel(labels ...string) issueFilter {
 			}
 		}
 
+		setIssueReason(ctx, "label:missing-required")
 		log.Tracef("issue #%d filtered out: missing required label", issue.Number)
 
 		return false
@@ -105,10 +112,11 @@ func issuesWithLabel(labels ...string) issueFilter {
 }
 
 func issuesWithoutLabel(labels ...string) issueFilter {
-	return func(issue ghIssue) bool {
+	return func(issue ghIssue, ctx ...*string) bool {
 		for _, targetLabel := range labels {
 			for _, l := range issue.Labels {
 				if l == targetLabel {
+					setIssueReason(ctx, "label:excluded:"+l)
 					log.Tracef("issue #%d filtered out: has label %q", issue.Number, l)
 
 					return false
@@ -120,12 +128,13 @@ func issuesWithoutLabel(labels ...string) issueFilter {
 }
 
 func excludeIssuesNotPlanned(allMergedPRs []ghPullRequest) issueFilter {
-	return func(issue ghIssue) bool {
+	return func(issue ghIssue, ctx ...*string) bool {
 		if issue.NotPlanned {
 			if len(getLinkedPRs(allMergedPRs, issue)) > 0 {
 				log.Tracef("issue #%d included: is closed as not planned but has linked PRs", issue.Number)
 				return true
 			}
+			setIssueReason(ctx, "closed-as:not-planned")
 			log.Tracef("issue #%d filtered out: as not planned", issue.Number)
 			return false
 		}
@@ -134,10 +143,11 @@ func excludeIssuesNotPlanned(allMergedPRs []ghPullRequest) issueFilter {
 }
 
 func issuesWithChangeTypes(config Config) issueFilter {
-	return func(issue ghIssue) bool {
+	return func(issue ghIssue, ctx ...*string) bool {
 		changeTypes := config.ChangeTypesByLabel.ChangeTypes(issue.Labels...)
 		keep := len(changeTypes) > 0
 		if !keep {
+			setIssueReason(ctx, "change-type:none")
 			log.Tracef("issue #%d filtered out: no change types", issue.Number)
 		}
 		return keep
@@ -145,12 +155,21 @@ func issuesWithChangeTypes(config Config) issueFilter {
 }
 
 func issuesWithoutLabels() issueFilter {
-	return func(issue ghIssue) bool {
+	return func(issue ghIssue, ctx ...*string) bool {
 		keep := len(issue.Labels) == 0
 		if !keep {
+			setIssueReason(ctx, "labels:present")
 			log.Tracef("issue #%d filtered out: has labels", issue.Number)
 		}
 		return keep
+	}
+}
+
+// setIssueReason writes the reason into the first element of the variadic ctx
+// slice, if provided and non-nil.
+func setIssueReason(ctx []*string, reason string) {
+	if len(ctx) > 0 && ctx[0] != nil {
+		*ctx[0] = reason
 	}
 }
 

--- a/chronicle/release/releasers/github/gh_pull_request.go
+++ b/chronicle/release/releasers/github/gh_pull_request.go
@@ -25,7 +25,15 @@ type ghPullRequest struct {
 	MergeCommit  string
 }
 
-type prFilter func(issue ghPullRequest) bool
+// prFilter decides whether to keep a PR. When returning false, the optional ctx
+// pointer (if non-nil) is populated with a short reason identifier.
+type prFilter func(pr ghPullRequest, ctx ...*string) bool
+
+// droppedPR pairs a PR with the reason it was filtered out.
+type droppedPR struct {
+	pr     ghPullRequest
+	reason string
+}
 
 func applyPRFilters(allMergedPRs []ghPullRequest, config Config, sinceTag, untilTag *git.Tag, includeCommits []string, filters ...prFilter) []ghPullRequest {
 	// first pass: exclude PRs which are not within the date range derived from the tags
@@ -40,45 +48,55 @@ func applyPRFilters(allMergedPRs []ghPullRequest, config Config, sinceTag, until
 		if len(reincluded) > 0 {
 			log.WithFields("count", len(reincluded)).Trace("PRs re-included by merge commit")
 		}
-		includedPRs = append(includedPRs, reincluded...)
+		includedPRs = append(includedPRs, prsFromDropped(reincluded)...)
 	}
 
 	// third pass: now that we have a list of PRs considered for release, we can filter down to those which have the correct traits (e.g. labels)
 	beforeQual := len(includedPRs)
-	var droppedQual []ghPullRequest
-	includedPRs, droppedQual = filterPRs(includedPRs, filters...)
+	includedPRs, droppedQual := filterPRs(includedPRs, filters...)
 	log.WithFields("kept", len(includedPRs), "dropped", len(droppedQual), "input", beforeQual).Trace("PR qualitative filter")
 
 	return includedPRs
 }
 
-func filterPRs(prs []ghPullRequest, filters ...prFilter) ([]ghPullRequest, []ghPullRequest) {
+// prsFromDropped extracts the underlying PR values from a dropped list.
+func prsFromDropped(dropped []droppedPR) []ghPullRequest {
+	prs := make([]ghPullRequest, len(dropped))
+	for i, d := range dropped {
+		prs[i] = d.pr
+	}
+	return prs
+}
+
+func filterPRs(prs []ghPullRequest, filters ...prFilter) (kept []ghPullRequest, dropped []droppedPR) {
 	if len(filters) == 0 {
 		return prs, nil
 	}
 
-	results := make([]ghPullRequest, 0, len(prs))
-	removed := make([]ghPullRequest, 0, len(prs))
+	kept = make([]ghPullRequest, 0, len(prs))
+	dropped = make([]droppedPR, 0, len(prs))
 
 prLoop:
-	for _, r := range prs {
+	for _, pr := range prs {
 		for _, f := range filters {
-			if !f(r) {
-				removed = append(removed, r)
+			var reason string
+			if !f(pr, &reason) {
+				dropped = append(dropped, droppedPR{pr: pr, reason: reason})
 				continue prLoop
 			}
 		}
-		results = append(results, r)
+		kept = append(kept, pr)
 	}
 
-	return results, removed
+	return kept, dropped
 }
 
 //nolint:unused
 func prsAtOrAfter(since time.Time) prFilter {
-	return func(pr ghPullRequest) bool {
+	return func(pr ghPullRequest, ctx ...*string) bool {
 		keep := pr.MergedAt.After(since) || pr.MergedAt.Equal(since)
 		if !keep {
+			setReason(ctx, "chronology:too-old")
 			log.Tracef("PR #%d filtered out: merged at or before %s (merged %s)", pr.Number, internal.FormatDateTime(since), internal.FormatDateTime(pr.MergedAt))
 		}
 		return keep
@@ -86,9 +104,10 @@ func prsAtOrAfter(since time.Time) prFilter {
 }
 
 func prsAtOrBefore(since time.Time) prFilter {
-	return func(pr ghPullRequest) bool {
+	return func(pr ghPullRequest, ctx ...*string) bool {
 		keep := pr.MergedAt.Before(since) || pr.MergedAt.Equal(since)
 		if !keep {
+			setReason(ctx, "chronology:too-new")
 			log.Tracef("PR #%d filtered out: merged at or after %s (merged %s)", pr.Number, internal.FormatDateTime(since), internal.FormatDateTime(pr.MergedAt))
 		}
 		return keep
@@ -96,9 +115,10 @@ func prsAtOrBefore(since time.Time) prFilter {
 }
 
 func prsAfter(since time.Time) prFilter {
-	return func(pr ghPullRequest) bool {
+	return func(pr ghPullRequest, ctx ...*string) bool {
 		keep := pr.MergedAt.After(since)
 		if !keep {
+			setReason(ctx, "chronology:too-old")
 			log.Tracef("PR #%d filtered out: merged before %s (merged %s)", pr.Number, internal.FormatDateTime(since), internal.FormatDateTime(pr.MergedAt))
 		}
 		return keep
@@ -107,9 +127,10 @@ func prsAfter(since time.Time) prFilter {
 
 //nolint:unused
 func prsBefore(since time.Time) prFilter {
-	return func(pr ghPullRequest) bool {
+	return func(pr ghPullRequest, ctx ...*string) bool {
 		keep := pr.MergedAt.Before(since)
 		if !keep {
+			setReason(ctx, "chronology:too-new")
 			log.Tracef("PR #%d filtered out: merged after %s (merged %s)", pr.Number, internal.FormatDateTime(since), internal.FormatDateTime(pr.MergedAt))
 		}
 		return keep
@@ -117,9 +138,10 @@ func prsBefore(since time.Time) prFilter {
 }
 
 func prsWithoutClosedLinkedIssue() prFilter {
-	return func(pr ghPullRequest) bool {
+	return func(pr ghPullRequest, ctx ...*string) bool {
 		for _, i := range pr.LinkedIssues {
 			if i.Closed {
+				setReason(ctx, "linked-issue:closed")
 				log.Tracef("PR #%d filtered out: has closed linked issue", pr.Number)
 				return false
 			}
@@ -129,21 +151,23 @@ func prsWithoutClosedLinkedIssue() prFilter {
 }
 
 func prsWithClosedLinkedIssue() prFilter {
-	return func(pr ghPullRequest) bool {
+	return func(pr ghPullRequest, ctx ...*string) bool {
 		for _, i := range pr.LinkedIssues {
 			if i.Closed {
 				return true
 			}
 		}
+		setReason(ctx, "linked-issue:none-closed")
 		log.Tracef("PR #%d filtered out: does not have a closed linked issue", pr.Number)
 		return false
 	}
 }
 
 func prsWithoutOpenLinkedIssue() prFilter {
-	return func(pr ghPullRequest) bool {
+	return func(pr ghPullRequest, ctx ...*string) bool {
 		for _, i := range pr.LinkedIssues {
 			if !i.Closed {
+				setReason(ctx, "linked-issue:open")
 				log.Tracef("PR #%d filtered out: has linked issue that is still open: issue %d", pr.Number, i.Number)
 
 				return false
@@ -154,7 +178,7 @@ func prsWithoutOpenLinkedIssue() prFilter {
 }
 
 func prsWithLabel(labels ...string) prFilter {
-	return func(pr ghPullRequest) bool {
+	return func(pr ghPullRequest, ctx ...*string) bool {
 		for _, targetLabel := range labels {
 			for _, l := range pr.Labels {
 				if l == targetLabel {
@@ -162,6 +186,7 @@ func prsWithLabel(labels ...string) prFilter {
 				}
 			}
 		}
+		setReason(ctx, "label:missing-required")
 		log.Tracef("PR #%d filtered out: missing required label", pr.Number)
 
 		return false
@@ -169,9 +194,10 @@ func prsWithLabel(labels ...string) prFilter {
 }
 
 func prsWithoutLabels() prFilter {
-	return func(pr ghPullRequest) bool {
+	return func(pr ghPullRequest, ctx ...*string) bool {
 		keep := len(pr.Labels) == 0
 		if !keep {
+			setReason(ctx, "labels:present")
 			log.Tracef("PR #%d filtered out: has labels", pr.Number)
 		}
 		return keep
@@ -179,9 +205,10 @@ func prsWithoutLabels() prFilter {
 }
 
 func prsWithoutLinkedIssues() prFilter {
-	return func(pr ghPullRequest) bool {
+	return func(pr ghPullRequest, ctx ...*string) bool {
 		keep := len(pr.LinkedIssues) == 0
 		if !keep {
+			setReason(ctx, "linked-issues:present")
 			log.Tracef("PR #%d filtered out: has linked issues", pr.Number)
 		}
 		return keep
@@ -189,11 +216,12 @@ func prsWithoutLinkedIssues() prFilter {
 }
 
 func prsWithChangeTypes(config Config) prFilter {
-	return func(pr ghPullRequest) bool {
+	return func(pr ghPullRequest, ctx ...*string) bool {
 		changeTypes := config.ChangeTypesByLabel.ChangeTypes(pr.Labels...)
 
 		keep := len(changeTypes) > 0
 		if !keep {
+			setReason(ctx, "change-type:none")
 			log.Tracef("PR #%d filtered out: no change types", pr.Number)
 		}
 		return keep
@@ -201,10 +229,11 @@ func prsWithChangeTypes(config Config) prFilter {
 }
 
 func prsWithoutLabel(labels ...string) prFilter {
-	return func(pr ghPullRequest) bool {
+	return func(pr ghPullRequest, ctx ...*string) bool {
 		for _, targetLabel := range labels {
 			for _, l := range pr.Labels {
 				if l == targetLabel {
+					setReason(ctx, "label:excluded:"+l)
 					log.Tracef("PR #%d filtered out: has label %q", pr.Number, l)
 					return false
 				}
@@ -217,8 +246,9 @@ func prsWithoutLabel(labels ...string) prFilter {
 
 func prsWithoutMergeCommit(commits ...string) prFilter {
 	commitSet := strset.New(commits...)
-	return func(pr ghPullRequest) bool {
+	return func(pr ghPullRequest, ctx ...*string) bool {
 		if !commitSet.Has(pr.MergeCommit) {
+			setReason(ctx, "merge-commit:not-in-set")
 			log.Tracef("PR #%d filtered out: has merge commit outside of valid set %s", pr.Number, pr.MergeCommit)
 			return false
 		}
@@ -227,21 +257,32 @@ func prsWithoutMergeCommit(commits ...string) prFilter {
 	}
 }
 
-func keepPRsWithCommits(prs []ghPullRequest, commits []string, filters ...prFilter) []ghPullRequest {
-	results := make([]ghPullRequest, 0, len(prs))
+func keepPRsWithCommits(dropped []droppedPR, commits []string, filters ...prFilter) []droppedPR {
+	results := make([]droppedPR, 0, len(dropped))
 
 	commitSet := strset.New(commits...)
-	for _, pr := range prs {
+	for _, d := range dropped {
+		pr := d.pr
 		if commitSet.Has(pr.MergeCommit) {
 			log.Tracef("PR #%d included: has selected commit %s", pr.Number, pr.MergeCommit)
 			keep, _ := filterPRs([]ghPullRequest{pr}, filters...)
-			results = append(results, keep...)
+			for _, kpr := range keep {
+				results = append(results, droppedPR{pr: kpr, reason: ""})
+			}
 		} else {
 			log.Tracef("PR #%d filtered out: does not have merge commit %s", pr.Number, pr.MergeCommit)
 		}
 	}
 
 	return results
+}
+
+// setReason writes the reason into the first element of the variadic ctx slice,
+// if provided and non-nil. This allows filter callers to retrieve the drop reason.
+func setReason(ctx []*string, reason string) {
+	if len(ctx) > 0 && ctx[0] != nil {
+		*ctx[0] = reason
+	}
 }
 
 //nolint:funlen

--- a/chronicle/release/releasers/github/summarizer.go
+++ b/chronicle/release/releasers/github/summarizer.go
@@ -424,7 +424,7 @@ func changesFromStandardPRFilters(config Config, allMergedPRs []ghPullRequest, s
 	includedPRs := applyStandardPRFilters(allMergedPRs, config, sinceTag, untilTag, includeCommits)
 
 	beforeChangeTypeFilter := len(includedPRs)
-	var droppedNoChangeType []ghPullRequest
+	var droppedNoChangeType []droppedPR
 	includedPRs, droppedNoChangeType = filterPRs(includedPRs, prsWithChangeTypes(config))
 	log.WithFields("kept", len(includedPRs), "dropped", len(droppedNoChangeType), "input", beforeChangeTypeFilter).Trace("PR change-type filter")
 
@@ -517,12 +517,12 @@ func changesFromUnlabeledPRs(config Config, allMergedPRs []ghPullRequest, sinceT
 
 	filters = append(filters, standardChronologicalPrFilters(config, sinceTag, untilTag, includeCommits)...)
 
-	filteredIssues, _ := filterPRs(allMergedPRs, filters...)
+	filteredPRs, _ := filterPRs(allMergedPRs, filters...)
 
-	log.WithFields("count", len(filteredIssues)).Info("unlabeled PRs contributing to changelog")
-	logPRs(filteredIssues)
+	log.WithFields("count", len(filteredPRs)).Info("unlabeled PRs contributing to changelog")
+	logPRs(filteredPRs)
 
-	return createChangesFromPRs(config, filteredIssues)
+	return createChangesFromPRs(config, filteredPRs)
 }
 
 func changesFromUnlabeledIssues(config Config, allMergedPRs []ghPullRequest, allIssues []ghIssue, sinceTag, untilTag *git.Tag) []change.Change {

--- a/chronicle/release/releasers/github/trunk.go
+++ b/chronicle/release/releasers/github/trunk.go
@@ -1,0 +1,279 @@
+package github
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/scylladb/go-set/strset"
+
+	"github.com/anchore/chronicle/chronicle/release"
+	"github.com/anchore/chronicle/chronicle/release/change"
+	"github.com/anchore/chronicle/internal/git"
+	"github.com/anchore/chronicle/internal/log"
+)
+
+var _ release.TrunkSummarizer = (*Summarizer)(nil)
+
+// Trunk produces commit-anchored release data for the trunk output format. The
+// "kept vs filtered" disposition for each PR/issue is derived from the actual
+// changelog pipeline (s.changes), so the trunk view always agrees with what
+// the markdown encoders would produce — including issue-driven configurations
+// where a PR contributes to the changelog via its closed linked issue rather
+// than via its own labels.
+func (s *Summarizer) Trunk(sinceRef, untilRef string) (*release.TrunkData, error) {
+	scope, err := s.getChangeScope(sinceRef, untilRef)
+	if err != nil {
+		return nil, err
+	}
+	if scope == nil {
+		return nil, errors.New("could not determine start/end of change range (no scope produced)")
+	}
+
+	// always fetch full commit metadata regardless of ConsiderPRMergeCommits
+	commits, err := s.git.CommitsBetweenWithMeta(git.Range{
+		SinceRef:     scope.Start.Ref,
+		UntilRef:     scope.End.Ref,
+		IncludeStart: scope.Start.Inclusive,
+		IncludeEnd:   true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	log.WithFields("count", len(commits)).Debug("commits fetched for trunk")
+
+	commitHashSet := strset.New()
+	for _, c := range commits {
+		commitHashSet.Add(c.Hash)
+	}
+
+	// run the full changelog pipeline so the trunk's kept/filtered decisions
+	// match exactly what shows up in the markdown changelog
+	keptChanges, err := s.changes(*scope)
+	if err != nil {
+		return nil, err
+	}
+
+	allMergedPRs, err := fetchMergedPRs(s.userName, s.repoName, scope.Start.Timestamp)
+	if err != nil {
+		return nil, err
+	}
+
+	log.WithFields("count", len(allMergedPRs), "since", scope.Start.Timestamp).Debug("merged PRs fetched for trunk")
+
+	keptByCommit := mapKeptChangesToCommits(keptChanges, allMergedPRs)
+
+	prMap := buildTrunkPRMap(s.config, allMergedPRs, commitHashSet, keptByCommit, scope.Start.Tag, scope.End.Tag)
+
+	trunkCommits := make([]release.TrunkCommit, 0, len(commits))
+	for _, c := range commits {
+		tc := release.TrunkCommit{
+			Hash:      c.Hash,
+			URL:       fmt.Sprintf("https://%s/%s/%s/commit/%s", s.config.Host, s.userName, s.repoName, c.Hash),
+			Subject:   c.Subject,
+			Author:    c.Author,
+			Timestamp: c.Timestamp,
+		}
+		if pr, ok := prMap[c.Hash]; ok {
+			tc.PR = pr
+		}
+		trunkCommits = append(trunkCommits, tc)
+	}
+
+	return &release.TrunkData{Commits: trunkCommits}, nil
+}
+
+// mapKeptChangesToCommits builds a map from merge-commit hash to the kept
+// changes that contributed via that commit. PR-changes map directly via
+// MergeCommit; issue-changes are mapped by finding the PR that closed the
+// issue (the issue's URL appears in the PR's LinkedIssues).
+func mapKeptChangesToCommits(keptChanges []change.Change, allMergedPRs []ghPullRequest) map[string][]change.Change {
+	out := make(map[string][]change.Change)
+	for _, c := range keptChanges {
+		commitHash := commitForKeptChange(c, allMergedPRs)
+		if commitHash == "" {
+			continue
+		}
+		out[commitHash] = append(out[commitHash], c)
+	}
+	return out
+}
+
+func commitForKeptChange(c change.Change, allMergedPRs []ghPullRequest) string {
+	switch entry := c.Entry.(type) {
+	case ghPullRequest:
+		return entry.MergeCommit
+	case ghIssue:
+		for _, pr := range allMergedPRs {
+			for _, linked := range pr.LinkedIssues {
+				if linked.URL == entry.URL {
+					return pr.MergeCommit
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// buildTrunkPRMap classifies all merged PRs whose MergeCommit is in the
+// provided commit set, returning a map keyed by merge-commit hash. PRs outside
+// the commit set are ignored entirely. A PR is "kept" if its commit appears in
+// keptByCommit (meaning the PR contributed to the changelog directly or via a
+// linked issue); otherwise a diagnostic reason is computed for display.
+func buildTrunkPRMap(config Config, allMergedPRs []ghPullRequest, commitHashSet *strset.Set, keptByCommit map[string][]change.Change, sinceTag, untilTag *git.Tag) map[string]*release.TrunkPR {
+	prMap := make(map[string]*release.TrunkPR)
+
+	for _, pr := range allMergedPRs {
+		if !commitHashSet.Has(pr.MergeCommit) {
+			continue
+		}
+
+		kept := keptByCommit[pr.MergeCommit]
+		if len(kept) > 0 {
+			prMap[pr.MergeCommit] = buildKeptTrunkPR(config, pr, kept, sinceTag, untilTag)
+			continue
+		}
+
+		prMap[pr.MergeCommit] = &release.TrunkPR{
+			Number:   pr.Number,
+			Title:    pr.Title,
+			URL:      pr.URL,
+			Author:   pr.Author,
+			Labels:   pr.Labels,
+			Filtered: true,
+			Reason:   explainPRNotKept(pr, config, sinceTag, untilTag),
+		}
+	}
+
+	return prMap
+}
+
+// buildKeptTrunkPR assembles a kept TrunkPR using change-types from whatever
+// kept change(s) actually contributed to the changelog (could be the PR
+// itself, or one or more linked issues, or both).
+func buildKeptTrunkPR(config Config, pr ghPullRequest, keptForCommit []change.Change, sinceTag, untilTag *git.Tag) *release.TrunkPR {
+	typeSet := make(map[string]change.Type)
+	keptIssueURLs := make(map[string]bool)
+	for _, kc := range keptForCommit {
+		for _, t := range kc.ChangeTypes {
+			typeSet[t.Name] = t
+		}
+		if issue, ok := kc.Entry.(ghIssue); ok {
+			keptIssueURLs[issue.URL] = true
+		}
+	}
+
+	changeTypes := make([]change.Type, 0, len(typeSet))
+	for _, t := range typeSet {
+		changeTypes = append(changeTypes, t)
+	}
+
+	return &release.TrunkPR{
+		Number:      pr.Number,
+		Title:       pr.Title,
+		URL:         pr.URL,
+		Author:      pr.Author,
+		Labels:      pr.Labels,
+		ChangeTypes: changeTypes,
+		Issues:      buildKeptTrunkIssues(config, pr.LinkedIssues, keptIssueURLs, sinceTag, untilTag),
+		Filtered:    false,
+	}
+}
+
+// buildKeptTrunkIssues classifies each linked issue: kept if its URL is in
+// keptURLs (meaning it contributed to the changelog), otherwise filtered with
+// a diagnostic reason. Open linked issues are skipped — they don't ship.
+func buildKeptTrunkIssues(config Config, linkedIssues []ghIssue, keptURLs map[string]bool, sinceTag, untilTag *git.Tag) []release.TrunkIssue {
+	if len(linkedIssues) == 0 {
+		return nil
+	}
+
+	result := make([]release.TrunkIssue, 0, len(linkedIssues))
+	for _, issue := range linkedIssues {
+		if !issue.Closed {
+			continue
+		}
+
+		ti := release.TrunkIssue{
+			Number: issue.Number,
+			Title:  issue.Title,
+			URL:    issue.URL,
+			Labels: issue.Labels,
+		}
+
+		if keptURLs[issue.URL] {
+			ti.ChangeTypes = config.ChangeTypesByLabel.ChangeTypes(issue.Labels...)
+			result = append(result, ti)
+			continue
+		}
+
+		ti.Filtered = true
+		ti.Reason = explainIssueNotKept(issue, config, sinceTag, untilTag)
+		result = append(result, ti)
+	}
+	return result
+}
+
+// explainPRNotKept runs the standard filter chain against a single PR and
+// returns the first failure reason. When the PR has a closed linked issue
+// (i.e., the contribution path is via the issue), the failure reason is
+// derived from the issue filters and prefixed with "linked-issue:".
+func explainPRNotKept(pr ghPullRequest, config Config, sinceTag, untilTag *git.Tag) string {
+	for _, f := range standardChronologicalPrFilters(config, sinceTag, untilTag, nil) {
+		var r string
+		if !f(pr, &r) {
+			return r
+		}
+	}
+
+	exclFilter := prsWithoutLabel(config.ExcludeLabels...)
+	var r string
+	if !exclFilter(pr, &r) {
+		return r
+	}
+
+	if hasClosedLinkedIssue(pr) {
+		// expected contribution path is via the linked issue
+		for _, linked := range pr.LinkedIssues {
+			if !linked.Closed {
+				continue
+			}
+			return "linked-issue:" + explainIssueNotKept(linked, config, sinceTag, untilTag)
+		}
+		return "linked-issue:not-included"
+	}
+
+	if !hasChangeTypeLabel(pr.Labels, config) {
+		return "label:missing-required"
+	}
+
+	return "not-included"
+}
+
+// explainIssueNotKept runs the standard issue filter chain and returns the
+// first failure reason.
+func explainIssueNotKept(issue ghIssue, config Config, sinceTag, untilTag *git.Tag) string {
+	for _, f := range standardIssueFilters(config, sinceTag, untilTag) {
+		var r string
+		if !f(issue, &r) {
+			return r
+		}
+	}
+	if !hasChangeTypeLabel(issue.Labels, config) {
+		return "label:missing-required"
+	}
+	return "not-included"
+}
+
+func hasClosedLinkedIssue(pr ghPullRequest) bool {
+	for _, linked := range pr.LinkedIssues {
+		if linked.Closed {
+			return true
+		}
+	}
+	return false
+}
+
+func hasChangeTypeLabel(labels []string, config Config) bool {
+	return len(config.ChangeTypesByLabel.ChangeTypes(labels...)) > 0
+}

--- a/chronicle/release/releasers/github/trunk_test.go
+++ b/chronicle/release/releasers/github/trunk_test.go
@@ -1,0 +1,947 @@
+package github
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/scylladb/go-set/strset"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/chronicle/chronicle/release"
+	"github.com/anchore/chronicle/chronicle/release/change"
+	"github.com/anchore/chronicle/internal/git"
+)
+
+// shared test fixtures for trunk tests
+var (
+	trunkPatch   = change.NewType("patch", change.SemVerPatch)
+	trunkFeature = change.NewType("added-feature", change.SemVerMinor)
+
+	trunkChangeTypes = change.TypeSet{
+		"bug":     trunkPatch,
+		"feature": trunkFeature,
+	}
+
+	trunkBaseTime = time.Date(2024, time.January, 10, 12, 0, 0, 0, time.UTC)
+)
+
+// makeKeptByCommit is a helper to build the keptByCommit map from explicit
+// commit→change pairs, avoiding repetitive map literal construction in tests.
+func makeKeptByCommit(pairs ...interface{}) map[string][]change.Change {
+	out := make(map[string][]change.Change)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		hash := pairs[i].(string)
+		c := pairs[i+1].(change.Change)
+		out[hash] = append(out[hash], c)
+	}
+	return out
+}
+
+// prChange builds a change.Change whose Entry is a ghPullRequest.
+func prChange(pr ghPullRequest, types ...change.Type) change.Change {
+	return change.Change{
+		ChangeTypes: types,
+		Entry:       pr,
+	}
+}
+
+// issueChange builds a change.Change whose Entry is a ghIssue.
+func issueChange(issue ghIssue, types ...change.Type) change.Change {
+	return change.Change{
+		ChangeTypes: types,
+		Entry:       issue,
+	}
+}
+
+// sortChangeTypes is a cmp option for order-independent ChangeTypes comparison.
+var sortChangeTypes = cmpopts.SortSlices(func(a, b change.Type) bool {
+	return a.Name < b.Name
+})
+
+// sortTrunkIssues is a cmp option for order-independent TrunkIssue slice comparison.
+var sortTrunkIssues = cmpopts.SortSlices(func(a, b release.TrunkIssue) bool {
+	return a.Number < b.Number
+})
+
+func Test_mapKeptChangesToCommits(t *testing.T) {
+	prHash := "aaaa1111"
+	issueHash := "bbbb2222"
+
+	pr := ghPullRequest{
+		Number:      10,
+		Title:       "fix bug via PR",
+		MergeCommit: prHash,
+		URL:         "https://github.com/owner/repo/pull/10",
+	}
+
+	issue := ghIssue{
+		Number: 20,
+		Title:  "fix bug via issue",
+		URL:    "https://github.com/owner/repo/issues/20",
+		Closed: true,
+	}
+
+	// a PR whose linked issues include our tracked issue
+	closingPR := ghPullRequest{
+		Number:      30,
+		Title:       "fix bug (closes issue 20)",
+		MergeCommit: issueHash,
+		LinkedIssues: []ghIssue{
+			{URL: issue.URL},
+		},
+	}
+
+	// a second PR for the multi-change-same-commit case
+	prHash2 := "cccc3333"
+	pr2 := ghPullRequest{
+		Number:      40,
+		Title:       "another fix via PR",
+		MergeCommit: prHash2,
+	}
+
+	tests := []struct {
+		name          string
+		keptChanges   []change.Change
+		allMergedPRs  []ghPullRequest
+		wantCommitMap map[string]int // commit hash → expected number of changes
+	}{
+		{
+			name:         "PR-change maps via its own MergeCommit",
+			keptChanges:  []change.Change{prChange(pr, trunkPatch)},
+			allMergedPRs: []ghPullRequest{pr},
+			wantCommitMap: map[string]int{
+				prHash: 1,
+			},
+		},
+		{
+			name:         "issue-change maps via the closing PR's MergeCommit",
+			keptChanges:  []change.Change{issueChange(issue, trunkFeature)},
+			allMergedPRs: []ghPullRequest{closingPR},
+			wantCommitMap: map[string]int{
+				issueHash: 1,
+			},
+		},
+		{
+			name:          "issue-change with no closing PR is omitted",
+			keptChanges:   []change.Change{issueChange(issue, trunkFeature)},
+			allMergedPRs:  []ghPullRequest{pr}, // pr does not link to issue
+			wantCommitMap: map[string]int{},
+		},
+		{
+			name: "multiple changes for same commit both appear",
+			keptChanges: []change.Change{
+				prChange(pr, trunkPatch),
+				prChange(pr, trunkFeature), // same PR, two separate kept changes
+			},
+			allMergedPRs: []ghPullRequest{pr},
+			wantCommitMap: map[string]int{
+				prHash: 2,
+			},
+		},
+		{
+			name: "mix of PR and issue changes across different commits",
+			keptChanges: []change.Change{
+				prChange(pr, trunkPatch),
+				issueChange(issue, trunkFeature),
+				prChange(pr2, trunkPatch),
+			},
+			allMergedPRs: []ghPullRequest{pr, closingPR, pr2},
+			wantCommitMap: map[string]int{
+				prHash:    1,
+				issueHash: 1,
+				prHash2:   1,
+			},
+		},
+		{
+			name:          "empty input produces empty map",
+			keptChanges:   nil,
+			allMergedPRs:  nil,
+			wantCommitMap: map[string]int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapKeptChangesToCommits(tt.keptChanges, tt.allMergedPRs)
+			require.Len(t, got, len(tt.wantCommitMap), "number of distinct commit hashes in result")
+			for hash, wantCount := range tt.wantCommitMap {
+				require.Contains(t, got, hash)
+				require.Len(t, got[hash], wantCount)
+			}
+		})
+	}
+}
+
+func Test_buildTrunkPRMap(t *testing.T) {
+	mergeHash := "deadbeef"
+	issueURL := "https://github.com/owner/repo/issues/99"
+
+	sinceTag := &git.Tag{
+		Name:      "v0.1.0",
+		Timestamp: trunkBaseTime.Add(-48 * time.Hour),
+	}
+	untilTag := &git.Tag{
+		Name:      "v0.2.0",
+		Timestamp: trunkBaseTime.Add(48 * time.Hour),
+	}
+
+	tests := []struct {
+		name         string
+		pr           ghPullRequest
+		keptByCommit map[string][]change.Change
+		config       Config
+		sinceTag     *git.Tag
+		untilTag     *git.Tag
+		// set skipCommitSet when the PR should not be in the commit set at all
+		skipCommitSet       bool
+		wantFiltered        bool
+		wantReason          string
+		wantChangeTypeNames []string // checked only when wantFiltered==false and non-nil
+	}{
+		{
+			// the syft case: PR carries no change-type labels, but its linked issue
+			// does. keptByCommit tells us which change-types were actually kept.
+			name: "PR kept via linked issue (syft case — PR has no change-type label)",
+			pr: ghPullRequest{
+				Number:      1,
+				Title:       "implement feature X",
+				MergeCommit: mergeHash,
+				Labels:      []string{}, // no change-type label on the PR itself
+				LinkedIssues: []ghIssue{
+					{Number: 99, URL: issueURL, Labels: []string{"feature"}, Closed: true},
+				},
+			},
+			keptByCommit: makeKeptByCommit(mergeHash, issueChange(
+				ghIssue{Number: 99, URL: issueURL, Labels: []string{"feature"}, Closed: true},
+				trunkFeature,
+			)),
+			config:              Config{ChangeTypesByLabel: trunkChangeTypes},
+			wantFiltered:        false,
+			wantChangeTypeNames: []string{"added-feature"},
+		},
+		{
+			// PR directly carries a change-type label and appears in keptByCommit
+			name: "PR kept directly via its own label",
+			pr: ghPullRequest{
+				Number:      2,
+				Title:       "fix regression",
+				MergeCommit: mergeHash,
+				Labels:      []string{"bug"},
+			},
+			keptByCommit: makeKeptByCommit(mergeHash, prChange(
+				ghPullRequest{Number: 2, MergeCommit: mergeHash, Labels: []string{"bug"}},
+				trunkPatch,
+			)),
+			config:              Config{ChangeTypesByLabel: trunkChangeTypes},
+			wantFiltered:        false,
+			wantChangeTypeNames: []string{"patch"},
+		},
+		{
+			// PR with no kept change → filtered; reason comes from explainPRNotKept
+			name: "PR filtered — no change-type label and not in keptByCommit",
+			pr: ghPullRequest{
+				Number:      3,
+				Title:       "docs update",
+				MergeCommit: mergeHash,
+				Labels:      []string{"documentation"},
+			},
+			keptByCommit: nil,
+			config:       Config{ChangeTypesByLabel: trunkChangeTypes},
+			wantFiltered: true,
+			wantReason:   "label:missing-required",
+		},
+		{
+			// PR outside commitHashSet → absent from result entirely
+			name: "PR outside commit set is ignored",
+			pr: ghPullRequest{
+				Number:      4,
+				Title:       "outside-range PR",
+				MergeCommit: "not-in-set",
+				Labels:      []string{"bug"},
+			},
+			keptByCommit:  nil,
+			config:        Config{ChangeTypesByLabel: trunkChangeTypes},
+			skipCommitSet: true,
+		},
+		{
+			// PR with an excluded label → filtered with "label:excluded:<name>"
+			name: "PR filtered — excluded label",
+			pr: ghPullRequest{
+				Number:      5,
+				Title:       "chore: bump deps",
+				MergeCommit: mergeHash,
+				Labels:      []string{"bug", "chore"},
+			},
+			keptByCommit: nil,
+			config: Config{
+				ChangeTypesByLabel: trunkChangeTypes,
+				ExcludeLabels:      []string{"chore"},
+			},
+			wantFiltered: true,
+			wantReason:   "label:excluded:chore",
+		},
+		{
+			// PR merged before sinceTag → "chronology:too-old" from prsAfter
+			name: "PR filtered — before since tag",
+			pr: ghPullRequest{
+				Number:      6,
+				Title:       "old fix",
+				MergeCommit: mergeHash,
+				Labels:      []string{"bug"},
+				MergedAt:    trunkBaseTime.Add(-72 * time.Hour),
+			},
+			keptByCommit: nil,
+			config:       Config{ChangeTypesByLabel: trunkChangeTypes},
+			sinceTag:     sinceTag,
+			untilTag:     untilTag,
+			wantFiltered: true,
+			wantReason:   "chronology:too-old",
+		},
+		{
+			// PR merged after untilTag → "chronology:too-new" from prsAtOrBefore
+			name: "PR filtered — after until tag",
+			pr: ghPullRequest{
+				Number:      7,
+				Title:       "future fix",
+				MergeCommit: mergeHash,
+				Labels:      []string{"bug"},
+				MergedAt:    trunkBaseTime.Add(96 * time.Hour),
+			},
+			keptByCommit: nil,
+			config:       Config{ChangeTypesByLabel: trunkChangeTypes},
+			sinceTag:     sinceTag,
+			untilTag:     untilTag,
+			wantFiltered: true,
+			wantReason:   "chronology:too-new",
+		},
+		{
+			// ChangeTypes is the union across all kept changes for that commit
+			name: "ChangeTypes unioned across multiple kept changes (patch + feature)",
+			pr: ghPullRequest{
+				Number:      8,
+				Title:       "big PR",
+				MergeCommit: mergeHash,
+				Labels:      []string{},
+			},
+			keptByCommit: map[string][]change.Change{
+				mergeHash: {
+					issueChange(ghIssue{Number: 1, URL: "u1"}, trunkPatch),
+					issueChange(ghIssue{Number: 2, URL: "u2"}, trunkFeature),
+				},
+			},
+			config:              Config{ChangeTypesByLabel: trunkChangeTypes},
+			wantFiltered:        false,
+			wantChangeTypeNames: []string{"patch", "added-feature"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.skipCommitSet {
+				// PR whose MergeCommit is not in the set should produce an empty map
+				prMap := buildTrunkPRMap(tt.config, []ghPullRequest{tt.pr}, strset.New("some-other-hash"), nil, nil, nil)
+				require.Empty(t, prMap)
+				return
+			}
+
+			commitSet := strset.New(mergeHash)
+			prMap := buildTrunkPRMap(tt.config, []ghPullRequest{tt.pr}, commitSet, tt.keptByCommit, tt.sinceTag, tt.untilTag)
+
+			require.Contains(t, prMap, mergeHash)
+			tp := prMap[mergeHash]
+
+			if tt.wantFiltered {
+				require.True(t, tp.Filtered, "expected PR to be filtered")
+				require.Equal(t, tt.wantReason, tp.Reason)
+			} else {
+				require.False(t, tp.Filtered, "expected PR to be kept")
+				require.Empty(t, tp.Reason)
+				if tt.wantChangeTypeNames != nil {
+					var gotNames []string
+					for _, ct := range tp.ChangeTypes {
+						gotNames = append(gotNames, ct.Name)
+					}
+					require.ElementsMatch(t, tt.wantChangeTypeNames, gotNames)
+				}
+			}
+		})
+	}
+}
+
+func Test_buildTrunkPRMap_prOutsideCommitSet(t *testing.T) {
+	// a PR whose MergeCommit is not in the commit set is silently skipped
+	pr := ghPullRequest{
+		Number:      99,
+		Title:       "some PR",
+		MergeCommit: "not-in-set",
+		Labels:      []string{"bug"},
+	}
+	commitSet := strset.New("some-other-hash")
+	cfg := Config{ChangeTypesByLabel: trunkChangeTypes}
+
+	prMap := buildTrunkPRMap(cfg, []ghPullRequest{pr}, commitSet, nil, nil, nil)
+
+	require.Empty(t, prMap)
+}
+
+func Test_buildTrunkPRMap_directCommitNotInPRMap(t *testing.T) {
+	// a commit hash that matches no PR.MergeCommit is absent from the map;
+	// TrunkCommit.PR stays nil for such commits.
+	directHash := "direct01"
+	prHash := "pr000001"
+
+	prs := []ghPullRequest{
+		{Number: 5, Title: "a PR", MergeCommit: prHash, Labels: []string{"bug"}},
+	}
+
+	commitSet := strset.New(directHash, prHash)
+	cfg := Config{ChangeTypesByLabel: trunkChangeTypes}
+
+	keptByCommit := makeKeptByCommit(prHash, prChange(prs[0], trunkPatch))
+	prMap := buildTrunkPRMap(cfg, prs, commitSet, keptByCommit, nil, nil)
+
+	require.Contains(t, prMap, prHash)
+	require.NotContains(t, prMap, directHash)
+}
+
+func Test_buildKeptTrunkPR(t *testing.T) {
+	sinceTag := &git.Tag{
+		Name:      "v0.1.0",
+		Timestamp: trunkBaseTime.Add(-24 * time.Hour),
+	}
+	untilTag := &git.Tag{
+		Name:      "v0.2.0",
+		Timestamp: trunkBaseTime.Add(24 * time.Hour),
+	}
+
+	keptIssueURL := "https://github.com/owner/repo/issues/10"
+	filteredIssueURL := "https://github.com/owner/repo/issues/11"
+
+	tests := []struct {
+		name          string
+		pr            ghPullRequest
+		keptForCommit []change.Change
+		config        Config
+		sinceTag      *git.Tag
+		untilTag      *git.Tag
+		// wantNoIssues is true when Issues should be nil or empty (open issues
+		// are skipped, returning an empty non-nil slice; no linked issues returns nil)
+		wantNoIssues     bool
+		wantIssueCount   int
+		wantChangeTypes  []string // expected type names, order-independent
+		checkIssueDetail func(t *testing.T, issues []release.TrunkIssue)
+	}{
+		{
+			name: "kept PR with no linked issues — Issues is nil",
+			pr: ghPullRequest{
+				Number:      1,
+				Title:       "fix via PR labels",
+				URL:         "https://github.com/owner/repo/pull/1",
+				Author:      "alice",
+				MergeCommit: "hash1",
+				Labels:      []string{"bug"},
+			},
+			keptForCommit: []change.Change{
+				prChange(ghPullRequest{Number: 1, MergeCommit: "hash1", Labels: []string{"bug"}}, trunkPatch),
+			},
+			config:          Config{ChangeTypesByLabel: trunkChangeTypes},
+			wantNoIssues:    true,
+			wantChangeTypes: []string{"patch"},
+		},
+		{
+			name: "kept PR with kept linked issue — Issues contains TrunkIssue with Filtered=false",
+			pr: ghPullRequest{
+				Number:      2,
+				Title:       "implement feature",
+				URL:         "https://github.com/owner/repo/pull/2",
+				Author:      "bob",
+				MergeCommit: "hash2",
+				Labels:      []string{},
+				LinkedIssues: []ghIssue{
+					{
+						Number:   10,
+						Title:    "add feature X",
+						URL:      keptIssueURL,
+						Labels:   []string{"feature"},
+						Closed:   true,
+						ClosedAt: trunkBaseTime,
+					},
+				},
+			},
+			keptForCommit: []change.Change{
+				issueChange(ghIssue{Number: 10, URL: keptIssueURL, Labels: []string{"feature"}, Closed: true}, trunkFeature),
+			},
+			config:          Config{ChangeTypesByLabel: trunkChangeTypes},
+			sinceTag:        sinceTag,
+			untilTag:        untilTag,
+			wantNoIssues:    false,
+			wantIssueCount:  1,
+			wantChangeTypes: []string{"added-feature"},
+			checkIssueDetail: func(t *testing.T, issues []release.TrunkIssue) {
+				t.Helper()
+				require.False(t, issues[0].Filtered)
+				require.Equal(t, 10, issues[0].Number)
+				require.Empty(t, issues[0].Reason)
+			},
+		},
+		{
+			// closed linked issue that was NOT included in keptForCommit →
+			// TrunkIssue with Filtered=true and a non-empty Reason
+			name: "kept PR with closed-but-not-kept linked issue — Issues contains Filtered TrunkIssue",
+			pr: ghPullRequest{
+				Number:      3,
+				Title:       "fix something",
+				MergeCommit: "hash3",
+				Labels:      []string{"bug"},
+				LinkedIssues: []ghIssue{
+					{
+						Number:   11,
+						Title:    "excluded issue",
+						URL:      filteredIssueURL,
+						Labels:   []string{"bug", "chore"},
+						Closed:   true,
+						ClosedAt: trunkBaseTime,
+					},
+				},
+			},
+			// keptForCommit references the PR itself, not the issue
+			keptForCommit: []change.Change{
+				prChange(ghPullRequest{Number: 3, MergeCommit: "hash3", Labels: []string{"bug"}}, trunkPatch),
+			},
+			config: Config{
+				ChangeTypesByLabel: trunkChangeTypes,
+				ExcludeLabels:      []string{"chore"},
+			},
+			sinceTag:       sinceTag,
+			untilTag:       untilTag,
+			wantNoIssues:   false,
+			wantIssueCount: 1,
+			checkIssueDetail: func(t *testing.T, issues []release.TrunkIssue) {
+				t.Helper()
+				require.True(t, issues[0].Filtered)
+				require.NotEmpty(t, issues[0].Reason)
+			},
+		},
+		{
+			// open linked issue is skipped by buildKeptTrunkIssues; the function
+			// returns an empty (non-nil) slice in this case
+			name: "kept PR with only open linked issue — Issues is empty",
+			pr: ghPullRequest{
+				Number:      4,
+				Title:       "partial implementation",
+				MergeCommit: "hash4",
+				Labels:      []string{"bug"},
+				LinkedIssues: []ghIssue{
+					{Number: 12, Title: "open issue", URL: "https://github.com/owner/repo/issues/12", Labels: []string{"bug"}, Closed: false},
+				},
+			},
+			keptForCommit: []change.Change{
+				prChange(ghPullRequest{Number: 4, MergeCommit: "hash4", Labels: []string{"bug"}}, trunkPatch),
+			},
+			config:          Config{ChangeTypesByLabel: trunkChangeTypes},
+			wantNoIssues:    true,
+			wantChangeTypes: []string{"patch"},
+		},
+		{
+			// ChangeTypes is the union of types from all kept changes for the commit
+			name: "ChangeTypes unioned from two kept issues with different types",
+			pr: ghPullRequest{
+				Number:      5,
+				Title:       "big feature+fix PR",
+				MergeCommit: "hash5",
+				Labels:      []string{},
+				LinkedIssues: []ghIssue{
+					{Number: 20, Title: "bug", URL: "https://github.com/owner/repo/issues/20", Labels: []string{"bug"}, Closed: true, ClosedAt: trunkBaseTime},
+					{Number: 21, Title: "feat", URL: "https://github.com/owner/repo/issues/21", Labels: []string{"feature"}, Closed: true, ClosedAt: trunkBaseTime},
+				},
+			},
+			keptForCommit: []change.Change{
+				issueChange(ghIssue{Number: 20, URL: "https://github.com/owner/repo/issues/20"}, trunkPatch),
+				issueChange(ghIssue{Number: 21, URL: "https://github.com/owner/repo/issues/21"}, trunkFeature),
+			},
+			config:          Config{ChangeTypesByLabel: trunkChangeTypes},
+			sinceTag:        sinceTag,
+			untilTag:        untilTag,
+			wantNoIssues:    false,
+			wantIssueCount:  2,
+			wantChangeTypes: []string{"patch", "added-feature"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildKeptTrunkPR(tt.config, tt.pr, tt.keptForCommit, tt.sinceTag, tt.untilTag)
+
+			require.NotNil(t, got)
+			require.False(t, got.Filtered)
+
+			if tt.wantNoIssues {
+				require.Empty(t, got.Issues)
+			} else {
+				require.Len(t, got.Issues, tt.wantIssueCount)
+			}
+
+			if tt.wantChangeTypes != nil {
+				var gotNames []string
+				for _, ct := range got.ChangeTypes {
+					gotNames = append(gotNames, ct.Name)
+				}
+				require.ElementsMatch(t, tt.wantChangeTypes, gotNames)
+			}
+
+			if tt.checkIssueDetail != nil {
+				tt.checkIssueDetail(t, got.Issues)
+			}
+		})
+	}
+}
+
+func Test_buildKeptTrunkIssues(t *testing.T) {
+	sinceTag := &git.Tag{
+		Name:      "v0.1.0",
+		Timestamp: trunkBaseTime.Add(-24 * time.Hour),
+	}
+	untilTag := &git.Tag{
+		Name:      "v0.2.0",
+		Timestamp: trunkBaseTime.Add(24 * time.Hour),
+	}
+
+	keptURL := "https://github.com/owner/repo/issues/1"
+	filteredURL := "https://github.com/owner/repo/issues/2"
+
+	tests := []struct {
+		name     string
+		issues   []ghIssue
+		keptURLs map[string]bool
+		config   Config
+		// wantEmpty is true when the result should be nil or empty
+		wantEmpty  bool
+		wantResult []release.TrunkIssue
+	}{
+		{
+			name:      "empty input returns nil",
+			issues:    nil,
+			wantEmpty: true,
+		},
+		{
+			// open issues are skipped; the pre-allocated slice is returned empty
+			name: "open issue is skipped — result is empty",
+			issues: []ghIssue{
+				{Number: 3, Title: "still open", URL: "u3", Labels: []string{"bug"}, Closed: false},
+			},
+			keptURLs:  map[string]bool{},
+			config:    Config{ChangeTypesByLabel: trunkChangeTypes},
+			wantEmpty: true,
+		},
+		{
+			name: "kept issue — Filtered=false with change types from config",
+			issues: []ghIssue{
+				{Number: 1, Title: "bug fix", URL: keptURL, Labels: []string{"bug"}, Closed: true, ClosedAt: trunkBaseTime},
+			},
+			keptURLs: map[string]bool{keptURL: true},
+			config:   Config{ChangeTypesByLabel: trunkChangeTypes},
+			wantResult: []release.TrunkIssue{
+				{Number: 1, Title: "bug fix", URL: keptURL, Labels: []string{"bug"}, ChangeTypes: []change.Type{trunkPatch}, Filtered: false},
+			},
+		},
+		{
+			name: "closed-but-not-kept issue — Filtered=true with non-empty Reason",
+			issues: []ghIssue{
+				{Number: 2, Title: "excluded", URL: filteredURL, Labels: []string{"bug", "chore"}, Closed: true, ClosedAt: trunkBaseTime},
+			},
+			keptURLs: map[string]bool{},
+			config: Config{
+				ChangeTypesByLabel: trunkChangeTypes,
+				ExcludeLabels:      []string{"chore"},
+			},
+			wantResult: []release.TrunkIssue{
+				{Number: 2, Title: "excluded", URL: filteredURL, Labels: []string{"bug", "chore"}, Filtered: true, Reason: "label:excluded:chore"},
+			},
+		},
+		{
+			name: "kept and filtered in same slice are each classified independently",
+			issues: []ghIssue{
+				{Number: 1, Title: "good", URL: keptURL, Labels: []string{"bug"}, Closed: true, ClosedAt: trunkBaseTime},
+				{Number: 2, Title: "excluded", URL: filteredURL, Labels: []string{"bug", "chore"}, Closed: true, ClosedAt: trunkBaseTime},
+			},
+			keptURLs: map[string]bool{keptURL: true},
+			config: Config{
+				ChangeTypesByLabel: trunkChangeTypes,
+				ExcludeLabels:      []string{"chore"},
+			},
+			wantResult: []release.TrunkIssue{
+				{Number: 1, Title: "good", URL: keptURL, Labels: []string{"bug"}, ChangeTypes: []change.Type{trunkPatch}, Filtered: false},
+				{Number: 2, Title: "excluded", URL: filteredURL, Labels: []string{"bug", "chore"}, Filtered: true, Reason: "label:excluded:chore"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildKeptTrunkIssues(tt.config, tt.issues, tt.keptURLs, sinceTag, untilTag)
+
+			if tt.wantEmpty {
+				require.Empty(t, got)
+				return
+			}
+
+			if diff := cmp.Diff(tt.wantResult, got, sortChangeTypes, sortTrunkIssues); diff != "" {
+				t.Errorf("buildKeptTrunkIssues mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_explainPRNotKept(t *testing.T) {
+	sinceTag := &git.Tag{
+		Name:      "v0.1.0",
+		Timestamp: trunkBaseTime.Add(-48 * time.Hour),
+	}
+	untilTag := &git.Tag{
+		Name:      "v0.2.0",
+		Timestamp: trunkBaseTime.Add(48 * time.Hour),
+	}
+
+	tests := []struct {
+		name       string
+		pr         ghPullRequest
+		config     Config
+		sinceTag   *git.Tag
+		untilTag   *git.Tag
+		wantReason string
+	}{
+		{
+			name: "PR merged before since tag — chronology:too-old",
+			pr: ghPullRequest{
+				Number:   1,
+				Labels:   []string{"bug"},
+				MergedAt: trunkBaseTime.Add(-96 * time.Hour),
+			},
+			config:     Config{ChangeTypesByLabel: trunkChangeTypes},
+			sinceTag:   sinceTag,
+			untilTag:   untilTag,
+			wantReason: "chronology:too-old",
+		},
+		{
+			name: "PR merged after until tag — chronology:too-new",
+			pr: ghPullRequest{
+				Number:   2,
+				Labels:   []string{"bug"},
+				MergedAt: trunkBaseTime.Add(96 * time.Hour),
+			},
+			config:     Config{ChangeTypesByLabel: trunkChangeTypes},
+			sinceTag:   sinceTag,
+			untilTag:   untilTag,
+			wantReason: "chronology:too-new",
+		},
+		{
+			name: "PR with excluded label — label:excluded:<name>",
+			pr: ghPullRequest{
+				Number:   3,
+				Labels:   []string{"bug", "chore"},
+				MergedAt: trunkBaseTime,
+			},
+			config: Config{
+				ChangeTypesByLabel: trunkChangeTypes,
+				ExcludeLabels:      []string{"chore"},
+			},
+			wantReason: "label:excluded:chore",
+		},
+		{
+			// PR has a closed linked issue whose issue lacks a change-type label;
+			// contribution path is "via linked issue" so reason is prefixed "linked-issue:"
+			name: "PR with closed linked issue that lacks change-type — linked-issue:label:missing-required",
+			pr: ghPullRequest{
+				Number:   4,
+				Labels:   []string{}, // no change-type on the PR
+				MergedAt: trunkBaseTime,
+				LinkedIssues: []ghIssue{
+					{Number: 99, Labels: []string{"documentation"}, Closed: true, ClosedAt: trunkBaseTime},
+				},
+			},
+			config:     Config{ChangeTypesByLabel: trunkChangeTypes},
+			sinceTag:   sinceTag,
+			untilTag:   untilTag,
+			wantReason: "linked-issue:label:missing-required",
+		},
+		{
+			// PR has no closed linked issue and no change-type label → direct path fails
+			name: "PR has no closed linked issue and no change-type label — label:missing-required",
+			pr: ghPullRequest{
+				Number:   5,
+				Labels:   []string{"documentation"},
+				MergedAt: trunkBaseTime,
+			},
+			config:     Config{ChangeTypesByLabel: trunkChangeTypes},
+			wantReason: "label:missing-required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := explainPRNotKept(tt.pr, tt.config, tt.sinceTag, tt.untilTag)
+			require.Equal(t, tt.wantReason, got)
+		})
+	}
+}
+
+func Test_explainIssueNotKept(t *testing.T) {
+	sinceTag := &git.Tag{
+		Name:      "v0.1.0",
+		Timestamp: trunkBaseTime.Add(-48 * time.Hour),
+	}
+	untilTag := &git.Tag{
+		Name:      "v0.2.0",
+		Timestamp: trunkBaseTime.Add(48 * time.Hour),
+	}
+
+	tests := []struct {
+		name       string
+		issue      ghIssue
+		config     Config
+		wantReason string
+	}{
+		{
+			name: "issue with excluded label",
+			issue: ghIssue{
+				Number:   1,
+				Labels:   []string{"bug", "chore"},
+				ClosedAt: trunkBaseTime,
+				Closed:   true,
+			},
+			config: Config{
+				ChangeTypesByLabel: trunkChangeTypes,
+				ExcludeLabels:      []string{"chore"},
+			},
+			// standardIssueFilters puts issuesWithLabel first; "bug" passes it.
+			// then issuesWithoutLabel fires on "chore"
+			wantReason: "label:excluded:chore",
+		},
+		{
+			// issue with no recognised change-type label fails issuesWithLabel first
+			name: "issue without change-type label — label:missing-required",
+			issue: ghIssue{
+				Number:   2,
+				Labels:   []string{"documentation"},
+				ClosedAt: trunkBaseTime,
+				Closed:   true,
+			},
+			config:     Config{ChangeTypesByLabel: trunkChangeTypes},
+			wantReason: "label:missing-required",
+		},
+		{
+			// "bug" label passes issuesWithLabel; then issuesAfter fires because
+			// the issue was closed before the sinceTag
+			name: "issue closed before since tag — chronology:before-since",
+			issue: ghIssue{
+				Number:   3,
+				Labels:   []string{"bug"},
+				ClosedAt: trunkBaseTime.Add(-96 * time.Hour),
+				Closed:   true,
+			},
+			config:     Config{ChangeTypesByLabel: trunkChangeTypes},
+			wantReason: "chronology:before-since",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := explainIssueNotKept(tt.issue, tt.config, sinceTag, untilTag)
+			require.Equal(t, tt.wantReason, got)
+		})
+	}
+}
+
+func Test_hasClosedLinkedIssue(t *testing.T) {
+	tests := []struct {
+		name string
+		pr   ghPullRequest
+		want bool
+	}{
+		{
+			name: "PR with closed linked issue — true",
+			pr: ghPullRequest{
+				LinkedIssues: []ghIssue{
+					{Number: 1, Closed: true},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "PR with only open linked issue — false",
+			pr: ghPullRequest{
+				LinkedIssues: []ghIssue{
+					{Number: 2, Closed: false},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "PR with no linked issues — false",
+			pr:   ghPullRequest{},
+			want: false,
+		},
+		{
+			name: "PR with mix of open and closed — true (has at least one closed)",
+			pr: ghPullRequest{
+				LinkedIssues: []ghIssue{
+					{Number: 3, Closed: false},
+					{Number: 4, Closed: true},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasClosedLinkedIssue(tt.pr)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_hasChangeTypeLabel(t *testing.T) {
+	cfg := Config{ChangeTypesByLabel: trunkChangeTypes}
+
+	tests := []struct {
+		name   string
+		labels []string
+		want   bool
+	}{
+		{
+			name:   "label matching a change type key — true",
+			labels: []string{"bug"},
+			want:   true,
+		},
+		{
+			name:   "another matching label — true",
+			labels: []string{"feature"},
+			want:   true,
+		},
+		{
+			name:   "no matching label — false",
+			labels: []string{"documentation", "chore"},
+			want:   false,
+		},
+		{
+			name:   "empty labels — false",
+			labels: nil,
+			want:   false,
+		},
+		{
+			name:   "mix of matching and non-matching — true",
+			labels: []string{"documentation", "bug"},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasChangeTypeLabel(tt.labels, cfg)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/chronicle/release/summarizer.go
+++ b/chronicle/release/summarizer.go
@@ -21,3 +21,10 @@ type Summarizer interface {
 	// ChangesURL is the URL to find the specific source changes that makeup this release, e.g. https://github.com/anchore/chronicle/compare/v0.3.0...v0.4.1 .
 	ChangesURL(sinceRef, untilRef string) string
 }
+
+// TrunkSummarizer is implemented by Summarizers that can produce commit-anchored
+// trunk data for the trunk output format. Returning nil means trunk data is
+// unavailable.
+type TrunkSummarizer interface {
+	Trunk(sinceRef, untilRef string) (*TrunkData, error)
+}

--- a/chronicle/release/trunk.go
+++ b/chronicle/release/trunk.go
@@ -1,0 +1,43 @@
+package release
+
+import (
+	"time"
+
+	"github.com/anchore/chronicle/chronicle/release/change"
+)
+
+// TrunkData carries commit-anchored release information for the trunk encoder.
+type TrunkData struct {
+	Commits []TrunkCommit // chronological, newest-first
+}
+
+type TrunkCommit struct {
+	Hash      string
+	URL       string // optional; populated by source-aware summarizers (e.g., github builds /owner/repo/commit/<hash>)
+	Subject   string // first line of the commit message; used as title when no PR maps to this commit
+	Author    string
+	Timestamp time.Time
+	PR        *TrunkPR // nil when no merge PR maps to this commit
+}
+
+type TrunkPR struct {
+	Number      int
+	Title       string
+	URL         string
+	Author      string
+	Labels      []string
+	ChangeTypes []change.Type
+	Issues      []TrunkIssue
+	Filtered    bool
+	Reason      string // populated when Filtered (e.g. "label:chore", "no change-type")
+}
+
+type TrunkIssue struct {
+	Number      int
+	Title       string
+	URL         string
+	Labels      []string
+	ChangeTypes []change.Type
+	Filtered    bool
+	Reason      string
+}

--- a/cmd/chronicle/cli/commands/create_github_worker.go
+++ b/cmd/chronicle/cli/commands/create_github_worker.go
@@ -11,6 +11,13 @@ import (
 )
 
 func createChangelogFromGithub(appConfig *createConfig) (*release.Release, *release.Description, error) {
+	// pre-flight: the trunk format encodes commit-level data that is only
+	// populated when consider-pr-merge-commits is enabled. Fail fast before
+	// any GitHub API work if the combination is invalid.
+	if err := checkTrunkPrerequisites(appConfig); err != nil {
+		return nil, nil, err
+	}
+
 	ghConfig := appConfig.Github.ToGithubConfig()
 
 	gitter, err := git.New(appConfig.RepoPath)
@@ -56,6 +63,23 @@ func createChangelogFromGithub(appConfig *createConfig) (*release.Release, *rele
 	}
 
 	return release.ChangelogInfo(summer, changelogConfig)
+}
+
+// checkTrunkPrerequisites returns an error when the trunk output format is
+// selected but consider-pr-merge-commits is disabled. The trunk encoder
+// requires commit-level data that is only collected when that setting is on.
+func checkTrunkPrerequisites(appConfig *createConfig) error {
+	specs, err := appConfig.Specs()
+	if err != nil {
+		return err
+	}
+
+	for _, spec := range specs {
+		if spec.Name == "trunk" && !appConfig.Github.ConsiderPRMergeCommits {
+			return fmt.Errorf(`the "trunk" output format requires "consider-pr-merge-commits=true"; either enable it (or pass --consider-pr-merge-commits) or remove "-o trunk"`)
+		}
+	}
+	return nil
 }
 
 func getGithubSupportedChanges(appConfig *createConfig) []change.TypeTitle {

--- a/cmd/chronicle/cli/options/output.go
+++ b/cmd/chronicle/cli/options/output.go
@@ -10,11 +10,18 @@ import (
 	jsonenc "github.com/anchore/chronicle/chronicle/release/output/encoders/json"
 	mdenc "github.com/anchore/chronicle/chronicle/release/output/encoders/markdown"
 	mdpretty "github.com/anchore/chronicle/chronicle/release/output/encoders/markdownpretty"
+	trunkenc "github.com/anchore/chronicle/chronicle/release/output/encoders/trunk"
 	versionenc "github.com/anchore/chronicle/chronicle/release/output/encoders/version"
 	"github.com/anchore/chronicle/internal/log"
 	"github.com/anchore/clio"
 	"github.com/anchore/fangs"
 )
+
+// TrunkOptions holds user-configurable settings for the trunk output format.
+type TrunkOptions struct {
+	Condensed    bool `yaml:"condensed" json:"condensed" mapstructure:"condensed"`
+	ShowFiltered bool `yaml:"show-filtered" json:"show-filtered" mapstructure:"show-filtered"`
+}
 
 // Output configures one or more `-o NAME[=PATH]` outputs for a command.
 // Embed this in a command's config (squashed) to expose the standard set
@@ -30,14 +37,17 @@ type Output struct {
 	// VersionFile is the deprecated --version-file path. It is folded into
 	// the spec list by Specs() and emits a deprecation warning when set.
 	VersionFile string `yaml:"version-file" json:"version-file" mapstructure:"version-file"`
+
+	// Trunk holds format-specific options for the trunk encoder.
+	Trunk TrunkOptions `yaml:"trunk" json:"trunk" mapstructure:"trunk"`
 }
 
 var _ clio.FlagAdder = (*Output)(nil)
 
 // DefaultOutput returns an Output with the standard chronicle encoder set
-// (md, json, version, md-pretty) wired up and a default of markdown-on-stdout.
-// TTY detection for md-pretty happens once at construction time; if stdout
-// later turns out to be piped, md-pretty falls back to plain markdown.
+// (md, json, version, md-pretty, trunk) wired up and a default of markdown-on-stdout.
+// TTY detection for md-pretty and trunk happens once at construction time; if stdout
+// later turns out to be piped, those encoders fall back gracefully.
 func DefaultOutput() Output {
 	return Output{
 		Available: output.NewEncoders(
@@ -45,8 +55,14 @@ func DefaultOutput() Output {
 			&jsonenc.Encoder{},
 			&versionenc.Encoder{},
 			&mdpretty.Encoder{IsTTY: isStdoutTTY()},
+			&trunkenc.Encoder{
+				IsTTY:        isStdoutTTY(),
+				Condensed:    true,
+				ShowFiltered: true,
+			},
 		),
 		Outputs: []string{mdenc.ID},
+		Trunk:   TrunkOptions{Condensed: true, ShowFiltered: true},
 	}
 }
 
@@ -65,6 +81,18 @@ func (o *Output) AddFlags(flags clio.FlagSet) {
 		&o.VersionFile,
 		"version-file", "",
 		"deprecated: use -o version=<path> instead",
+	)
+
+	flags.BoolVarP(
+		&o.Trunk.Condensed,
+		"trunk-condensed", "",
+		"trunk format: one row per commit (set to false for expanded, multi-row output)",
+	)
+
+	flags.BoolVarP(
+		&o.Trunk.ShowFiltered,
+		"trunk-show-filtered", "",
+		"trunk format: show non-contributing commits and filtered PRs/issues dimmed",
 	)
 
 	// MarkDeprecated both hides the flag from help and prints a one-time
@@ -102,8 +130,18 @@ func (o *Output) Check() error {
 }
 
 // Writer constructs the output writer for the configured specs, validated
-// against this Output's available encoder set.
+// against this Output's available encoder set. The trunk encoder is refreshed
+// from the current TrunkOptions so that flag-parsed values take effect even
+// though the encoder was constructed before flag parsing ran.
 func (o *Output) Writer() (output.Writer, error) {
+	// refresh trunk encoder fields from the (now flag-parsed) TrunkOptions
+	if enc, ok := o.Available[trunkenc.ID]; ok {
+		if te, ok := enc.(*trunkenc.Encoder); ok {
+			te.Condensed = o.Trunk.Condensed
+			te.ShowFiltered = o.Trunk.ShowFiltered
+		}
+	}
+
 	specs, err := o.Specs()
 	if err != nil {
 		return nil, err

--- a/cmd/chronicle/cli/options/output_test.go
+++ b/cmd/chronicle/cli/options/output_test.go
@@ -78,7 +78,7 @@ func TestOutput_Specs(t *testing.T) {
 
 func TestDefaultOutput_Encoders(t *testing.T) {
 	o := DefaultOutput()
-	require.ElementsMatch(t, []string{"md", "json", "version", "md-pretty"}, o.Available.Names())
+	require.ElementsMatch(t, []string{"md", "json", "version", "md-pretty", "trunk"}, o.Available.Names())
 }
 
 // TestOutput_Writer_EndToEnd is the seam between the cmd layer and the output

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/anchore/fangs v0.0.0-20250319155437-a26984174d7d
 	github.com/anchore/go-logger v0.1.0
 	github.com/charmbracelet/glamour v1.0.0
+	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/coreos/go-semver v0.3.1
 	github.com/gkampitakis/go-snaps v0.5.21
 	github.com/go-git/go-billy/v5 v5.8.0
@@ -14,6 +15,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/leodido/go-conventionalcommits v0.12.0
 	github.com/muesli/termenv v0.16.0
+	github.com/savioxavier/termlink v1.4.3
 	github.com/scylladb/go-set v1.0.2
 	github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa
 	github.com/spf13/cobra v1.10.2
@@ -33,7 +35,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 // indirect
 	github.com/charmbracelet/x/ansi v0.10.2 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/leodido/go-conventionalcommits v0.12.0
 	github.com/muesli/termenv v0.16.0
-	github.com/savioxavier/termlink v1.4.3
 	github.com/scylladb/go-set v1.0.2
 	github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
+github.com/savioxavier/termlink v1.4.3 h1:Gh6vrG7jSn21cRiYdQqFXYcdXfM+Fg14aG487JTfKpA=
+github.com/savioxavier/termlink v1.4.3/go.mod h1:5T5ePUlWbxCHIwyF8/Ez1qufOoGM89RCg9NvG+3G3gc=
 github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
 github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,6 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
-github.com/savioxavier/termlink v1.4.3 h1:Gh6vrG7jSn21cRiYdQqFXYcdXfM+Fg14aG487JTfKpA=
-github.com/savioxavier/termlink v1.4.3/go.mod h1:5T5ePUlWbxCHIwyF8/Ez1qufOoGM89RCg9NvG+3G3gc=
 github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
 github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=

--- a/internal/git/interface.go
+++ b/internal/git/interface.go
@@ -15,6 +15,7 @@ type Interface interface {
 	SearchForTag(tagRef string) (*Tag, error)
 	TagsFromLocal() ([]Tag, error)
 	CommitsBetween(Range) ([]string, error)
+	CommitsBetweenWithMeta(Range) ([]Commit, error)
 }
 
 type gitter struct {
@@ -36,6 +37,10 @@ func New(repoPath string) (Interface, error) {
 
 func (g gitter) CommitsBetween(cfg Range) ([]string, error) {
 	return CommitsBetween(g.repoPath, cfg)
+}
+
+func (g gitter) CommitsBetweenWithMeta(cfg Range) ([]Commit, error) {
+	return CommitsBetweenWithMeta(g.repoPath, cfg)
 }
 
 func (g gitter) HeadTagOrCommit() (string, error) {

--- a/internal/git/mock_git.go
+++ b/internal/git/mock_git.go
@@ -3,17 +3,22 @@ package git
 var _ Interface = (*MockInterface)(nil)
 
 type MockInterface struct {
-	MockHeadOrTagCommit string
-	MockHeadTag         string
-	MockTags            []string
-	MockRemoteURL       string
-	MockSearchTag       string
-	MockCommitsBetween  []string
-	MockFirstCommit     string
+	MockHeadOrTagCommit        string
+	MockHeadTag                string
+	MockTags                   []string
+	MockRemoteURL              string
+	MockSearchTag              string
+	MockCommitsBetween         []string
+	MockCommitsBetweenWithMeta []Commit
+	MockFirstCommit            string
 }
 
 func (m MockInterface) CommitsBetween(_ Range) ([]string, error) {
 	return m.MockCommitsBetween, nil
+}
+
+func (m MockInterface) CommitsBetweenWithMeta(_ Range) ([]Commit, error) {
+	return m.MockCommitsBetweenWithMeta, nil
 }
 
 func (m MockInterface) HeadTagOrCommit() (string, error) {

--- a/internal/git/tag.go
+++ b/internal/git/tag.go
@@ -3,6 +3,7 @@ package git
 import (
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	git "github.com/go-git/go-git/v5"
@@ -25,6 +26,14 @@ type Range struct {
 	UntilRef     string
 	IncludeStart bool
 	IncludeEnd   bool
+}
+
+// Commit holds lightweight metadata extracted from a single git commit.
+type Commit struct {
+	Hash      string
+	Subject   string // first line of the commit message
+	Author    string
+	Timestamp time.Time
 }
 
 func CommitsBetween(repoPath string, cfg Range) ([]string, error) {
@@ -69,6 +78,67 @@ func CommitsBetween(repoPath string, cfg Range) ([]string, error) {
 			}
 		default:
 			commits = append(commits, hash)
+		}
+
+		return
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error walking commits between %q..%q: %w", cfg.SinceRef, cfg.UntilRef, err)
+	}
+
+	return commits, nil
+}
+
+// CommitsBetweenWithMeta walks the same range as CommitsBetween but returns
+// full commit metadata instead of just hashes.
+func CommitsBetweenWithMeta(repoPath string, cfg Range) ([]Commit, error) {
+	r, err := openRepo(repoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var sinceHash *plumbing.Hash
+	if cfg.SinceRef != "" {
+		sinceHash, err = r.ResolveRevision(plumbing.Revision(cfg.SinceRef))
+		if err != nil {
+			return nil, fmt.Errorf("unable to find since git ref=%q: %w", cfg.SinceRef, err)
+		}
+	}
+
+	untilHash, err := r.ResolveRevision(plumbing.Revision(cfg.UntilRef))
+	if err != nil {
+		return nil, fmt.Errorf("unable to find until git ref=%q: %w", cfg.UntilRef, err)
+	}
+
+	iter, err := r.Log(&git.LogOptions{From: *untilHash})
+	if err != nil {
+		return nil, fmt.Errorf("unable to find until git log for ref=%q: %w", cfg.UntilRef, err)
+	}
+
+	log.WithFields("since", sinceHash, "until", untilHash).Trace("searching commit range")
+
+	var commits []Commit
+	err = iter.ForEach(func(c *object.Commit) (retErr error) {
+		subject := strings.TrimSpace(strings.SplitN(c.Message, "\n", 2)[0])
+		entry := Commit{
+			Hash:      c.Hash.String(),
+			Subject:   subject,
+			Author:    c.Author.Name,
+			Timestamp: c.Author.When,
+		}
+
+		switch {
+		case untilHash != nil && c.Hash == *untilHash:
+			if cfg.IncludeEnd {
+				commits = append(commits, entry)
+			}
+		case sinceHash != nil && c.Hash == *sinceHash:
+			retErr = storer.ErrStop
+			if cfg.IncludeStart {
+				commits = append(commits, entry)
+			}
+		default:
+			commits = append(commits, entry)
 		}
 
 		return

--- a/internal/git/tag_test.go
+++ b/internal/git/tag_test.go
@@ -215,6 +215,117 @@ func TestCommitsBetween(t *testing.T) {
 	}
 }
 
+func TestCommitsBetweenWithMeta(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		config  Range
+		count   int
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "all inclusive",
+			path: "testdata/repos/tag-range-repo",
+			config: Range{
+				SinceRef:     "v0.1.0",
+				UntilRef:     "v0.1.1",
+				IncludeStart: true,
+				IncludeEnd:   true,
+			},
+			count: 4,
+		},
+		{
+			name: "exclude start and end",
+			path: "testdata/repos/tag-range-repo",
+			config: Range{
+				SinceRef:     "v0.1.0",
+				UntilRef:     "v0.1.1",
+				IncludeStart: false,
+				IncludeEnd:   false,
+			},
+			count: 2,
+		},
+		{
+			name: "invalid since ref",
+			path: "testdata/repos/tag-range-repo",
+			config: Range{
+				SinceRef: "v999.999.999",
+				UntilRef: "v0.1.1",
+			},
+			wantErr: require.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
+			}
+
+			got, err := CommitsBetweenWithMeta(tt.path, tt.config)
+			tt.wantErr(t, err)
+			if err != nil {
+				return
+			}
+
+			require.Len(t, got, tt.count)
+
+			// build expected commits from git directly and compare metadata fields
+			expected := gitCommitsWithMeta(t, tt.path, tt.config)
+			if diff := cmp.Diff(expected, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// gitCommitsWithMeta queries git directly to produce the expected []Commit slice
+// for the given range, honoring IncludeStart and IncludeEnd.
+func gitCommitsWithMeta(t *testing.T, path string, cfg Range) []Commit {
+	t.Helper()
+
+	// use the same inclusive range trick as gitLogRange: since~1..until
+	cmd := exec.Command("git", "--no-pager", "log",
+		`--pretty=format:%H|%s|%an|%aI`,
+		fmt.Sprintf("%s~1..%s", cfg.SinceRef, cfg.UntilRef),
+	)
+	cmd.Dir = path
+	output, err := cmd.Output()
+	require.NoError(t, err)
+
+	rows := strings.Split(strings.TrimSpace(string(output)), "\n")
+
+	var commits []Commit
+	for _, row := range rows {
+		if row == "" {
+			continue
+		}
+		parts := strings.SplitN(row, "|", 4)
+		require.Len(t, parts, 4, "unexpected git log row: %q", row)
+
+		ts, err := time.Parse(time.RFC3339, parts[3])
+		require.NoError(t, err)
+
+		commits = append(commits, Commit{
+			Hash:      parts[0],
+			Subject:   parts[1],
+			Author:    parts[2],
+			Timestamp: ts,
+		})
+	}
+
+	if !cfg.IncludeStart {
+		// git log is in reverse chronological order; start commit is at the back
+		commits = commits[:len(commits)-1]
+	}
+	if !cfg.IncludeEnd {
+		// end commit is at the front
+		commits = commits[1:]
+	}
+
+	return commits
+}
+
 func gitLogRange(t *testing.T, path, since, until string) []string {
 	t.Helper()
 


### PR DESCRIPTION
Now that we support multiple output formats, and the changelog tends to be redirected to a file, we could support a better experience for understanding the set of results we get from git and the github api, not just show the final changelog. Something that squares the set of commits that comprise the release with which PRs they are associated with and the issues they close, including the items that are ignored. 

That's what lead to a trunk based output:

<img width="1157" height="443" alt="Screenshot 2026-05-07 at 5 40 01 PM" src="https://github.com/user-attachments/assets/86c9d13f-bf72-4984-b456-cfa11a548bc8" />
