### PR TITLE
Tighten workflow-level permissions to empty default

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,6 @@
 name: "Release"
 
-permissions:
-  contents: read
-  checks: read
+permissions: {}
 
 concurrency:
   group: release
@@ -23,6 +21,8 @@ jobs:
       version: ${{ github.event.inputs.version }}
 
   check-gate:
+    permissions:
+      checks: read   # required for getting the status of specific check names
     uses: anchore/workflows/.github/workflows/check-gate.yaml@4f25313f96311410cad4173f74617654a3e46d48 # v0.3.0
     with:
       checks: '["Static analysis", "Unit tests", "Build snapshot artifacts"]'

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -7,8 +7,7 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   Static-Analysis:
@@ -33,6 +32,8 @@ jobs:
     name: "Unit tests"
     needs: All-Unit-Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - run: echo All Unit Tests passed
 


### PR DESCRIPTION
Tightens workflow-level permissions across three workflows. Top-level `permissions:` blocks were granting read access to all jobs; moved the actual permissions down to the individual jobs that need them.

Changes:
- release.yaml: top-level `permissions: { contents: read, checks: read }` → `permissions: {}`; `checks: read` pushed to the check-gate job (release job already had its own block)
- validate-github-actions.yaml: top-level `permissions: { contents: read }` → `permissions: {}`; zizmor job already had its own block
- validations.yaml: top-level `permissions: { contents: read }` → `permissions: {}`; added explicit `contents: read` to Unit-Test job which had no job-level block
