### PR TITLE
Add conventional commit deduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,12 @@ github:
   # issues can only be considered for changelog candidates if they have linked PRs that are merged (note: does NOT require github.include-issues to be set)
   # same as CHRONICLE_GITHUB_ISSUES_REQUIRE_LINKED_PRS env var
   issues-require-linked-prs: false
-  
+
+  # when a merged PR has no change-type label, infer the change type from a conventional-commit
+  # prefix in the PR title (e.g. "feat: ..." -> Added Features). An explicit label always wins.
+  # same as CHRONICLE_GITHUB_INFER_CHANGE_TYPE_FROM_TITLE env var
+  infer-change-type-from-title: true
+
   # list of definitions of what labels applied to issues or PRs constitute a changelog entry. These entries also dictate 
   # the changelog section, the changelog title, and the semver field that best represents the class of change.
   # note: cannot be set via environment variables
@@ -172,6 +177,7 @@ The `github.changes` configurable is a list of mappings, each that take the foll
 - `title`: _[string]_ title of the section in the changelog listing all entries.
 - `semver-field`: _[string]_ change entries will bump the respective semver field when guessing the next release version. Allowable values: `major`, `minor`, or `patch`.
 - `labels`: _[list of strings]_ all issue or PR labels that should match this change section.
+- `prefixes`: _[list of strings]_ [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/#specification) type prefixes that map to this change section when `github.infer-change-type-from-title` is enabled and a PR carries no change-type label (e.g. `feat`, `fix`). Prefixes are matched case-insensitively. Use the special value `!` to match the conventional-commit breaking-change marker (e.g. a `feat!: ...` title); if a PR title carries a `!` marker but no change section declares the `!` prefix, chronicle logs a warning and falls back to the base type (so the breaking change won't bump the major version). Only applies to PRs, not issues; an explicit label always takes precedence over an inferred prefix.
 
 The default value for `github.changes` is:
 
@@ -190,6 +196,8 @@ The default value for `github.changes` is:
     - enhancement
     - feature
     - minor
+  prefixes:
+    - feat
   
 - name: bug-fix
   title: Bug Fixes
@@ -199,6 +207,17 @@ The default value for `github.changes` is:
     - fix
     - bug-fix
     - patch
+  prefixes:
+    - fix
+
+- name: performance
+  title: Performance
+  semver-field: patch
+  labels:
+    - performance
+    - perf
+  prefixes:
+    - perf
   
 - name: breaking-feature
   title: Breaking Changes
@@ -209,6 +228,8 @@ The default value for `github.changes` is:
     - breaking-change
     - breaking-feature
     - major
+  prefixes:
+    - "!"
     
 - name: removed-feature
   title: Removed Features

--- a/chronicle/release/change/conventionalcommit.go
+++ b/chronicle/release/change/conventionalcommit.go
@@ -1,0 +1,85 @@
+package change
+
+import (
+	"strings"
+
+	conventionalcommits "github.com/leodido/go-conventionalcommits"
+	ccparser "github.com/leodido/go-conventionalcommits/parser"
+)
+
+// BreakingChangePrefix is the sentinel "prefix" used to map the conventional-commit
+// breaking-change marker ("!") to a change type, e.g. "feat!: ...".
+const BreakingChangePrefix = "!"
+
+// parseConventionalCommit parses a subject line as a conventional commit using
+// the given type set. ok is false when the subject is not a conventional commit.
+func parseConventionalCommit(title string, types conventionalcommits.TypeConfig) (*conventionalcommits.ConventionalCommit, bool) {
+	msg, err := ccparser.NewMachine(ccparser.WithTypes(types)).Parse([]byte(title))
+	if err != nil || msg == nil || !msg.Ok() {
+		return nil, false
+	}
+	cc, ok := msg.(*conventionalcommits.ConventionalCommit)
+	if !ok {
+		return nil, false
+	}
+	return cc, true
+}
+
+// ParseConventionalCommit reports the conventional-commit type (e.g. "feat",
+// "fix") and whether the subject marks a breaking change. ok is false when the
+// subject is not a conventional commit. A PR title carries no body or footer, so
+// the trailing "!" before the colon is the only breaking signal we can observe.
+//
+// Free-form types are used so arbitrary (user-configured) prefixes parse rather
+// than being gated by the library's built-in conventional type whitelist;
+// callers decide which prefixes are meaningful via their own configured mapping.
+func ParseConventionalCommit(title string) (ccType string, breaking bool, ok bool) {
+	cc, ok := parseConventionalCommit(title, conventionalcommits.TypesFreeForm)
+	if !ok {
+		return "", false, false
+	}
+	return cc.Type, cc.IsBreakingChange(), true
+}
+
+// TrimConventionalCommitPrefix removes a leading conventional-commit prefix
+// (e.g. "feat: ", "fix(scope)!: ") from a subject line, returning the bare
+// description. The standard conventional-commit types are always recognized;
+// recognizedTypes additionally allows caller-configured (non-standard) type
+// prefixes — the same ones used to drive categorization — to be trimmed, so the
+// display text stays consistent with how the subject was classified. An
+// arbitrary "word: ..." subject with an unrecognized prefix is returned
+// unchanged.
+func TrimConventionalCommitPrefix(title string, recognizedTypes ...string) string {
+	// standard conventional types are always trimmed.
+	if _, ok := parseConventionalCommit(title, conventionalcommits.TypesConventional); ok {
+		return trimAfterColon(title)
+	}
+	// otherwise only trim when the (free-form) type prefix is one the caller
+	// recognizes. Free-form parsing lets any "word: ..." prefix parse, so the
+	// recognized set gates which ones we actually strip — unrelated subjects like
+	// "feature: ..." are left intact.
+	if cc, ok := parseConventionalCommit(title, conventionalcommits.TypesFreeForm); ok && containsFold(recognizedTypes, cc.Type) {
+		return trimAfterColon(title)
+	}
+	return title
+}
+
+// trimAfterColon returns the subject text following the first ":", trimmed of
+// surrounding whitespace. We split rather than use the parsed description to
+// preserve the original (untrimmed-by-the-grammar) message verbatim.
+func trimAfterColon(title string) string {
+	if fields := strings.SplitN(title, ":", 2); len(fields) == 2 {
+		return strings.TrimSpace(fields[1])
+	}
+	return title
+}
+
+// containsFold reports whether needle is in haystack, compared case-insensitively.
+func containsFold(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if strings.EqualFold(h, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/chronicle/release/change/conventionalcommit_test.go
+++ b/chronicle/release/change/conventionalcommit_test.go
@@ -1,0 +1,133 @@
+package change
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ParseConventionalCommit(t *testing.T) {
+	tests := []struct {
+		name         string
+		title        string
+		wantType     string
+		wantBreaking bool
+		wantOk       bool
+	}{
+		{
+			name:     "simple feat",
+			title:    "feat: add user authentication",
+			wantType: "feat",
+			wantOk:   true,
+		},
+		{
+			name:     "fix with scope",
+			title:    "fix(parser): resolve null pointer",
+			wantType: "fix",
+			wantOk:   true,
+		},
+		{
+			name:         "breaking feat via bang",
+			title:        "feat!: drop legacy API",
+			wantType:     "feat",
+			wantBreaking: true,
+			wantOk:       true,
+		},
+		{
+			name:         "breaking with scope and bang",
+			title:        "fix(api)!: change response shape",
+			wantType:     "fix",
+			wantBreaking: true,
+			wantOk:       true,
+		},
+		{
+			name:     "perf",
+			title:    "perf: speed up lookups",
+			wantType: "perf",
+			wantOk:   true,
+		},
+		{
+			name:     "free-form custom type parses",
+			title:    "wibble: a custom prefix",
+			wantType: "wibble",
+			wantOk:   true,
+		},
+		{
+			name:   "not a conventional commit",
+			title:  "Bump foo to v2",
+			wantOk: false,
+		},
+		{
+			name:   "type without colon",
+			title:  "fix",
+			wantOk: false,
+		},
+		{
+			name:   "empty description",
+			title:  "feat(scope):   ",
+			wantOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotBreaking, gotOk := ParseConventionalCommit(tt.title)
+			assert.Equal(t, tt.wantOk, gotOk)
+
+			if !gotOk {
+				return
+			}
+			assert.Equal(t, tt.wantType, gotType)
+			assert.Equal(t, tt.wantBreaking, gotBreaking)
+		})
+	}
+}
+
+func Test_TrimConventionalCommitPrefix(t *testing.T) {
+	tests := []struct {
+		title      string
+		recognized []string
+		want       string
+	}{
+		// positive cases
+		{title: "feat: add user authentication", want: "add user authentication"},
+		{title: "fix: resolve null pointer exception", want: "resolve null pointer exception"},
+		{title: "docs: update README", want: "update README"},
+		{title: "style: format code according to style guide", want: "format code according to style guide"},
+		{title: "refactor: extract reusable function", want: "extract reusable function"},
+		{title: "perf: optimize database queries", want: "optimize database queries"},
+		{title: "test: add unit tests", want: "add unit tests"},
+		{title: "build: update build process", want: "update build process"},
+		{title: "ci: configure Travis CI", want: "configure Travis CI"},
+		{title: "chore: perform maintenance tasks", want: "perform maintenance tasks"},
+		// positive case odd balls
+		{title: "chore: can end with punctuation.", want: "can end with punctuation."},
+		{title: "revert!: revert: previous: commit", want: "revert: previous: commit"},
+		{title: "feat(api)!: implement new: API endpoints", want: "implement new: API endpoints"},
+		{title: "feat!: add awesome new feature (closes #123)", want: "add awesome new feature (closes #123)"},
+		{title: "fix(ui): fix layout issue (fixes #456)", want: "fix layout issue (fixes #456)"},
+		// negative cases (only standard conventional types are recognized)
+		{title: "reallycoolthing: is done!", want: "reallycoolthing: is done!"},
+		{title: "feature: is done!", want: "feature: is done!"},
+		{title: "feat(scope):   ", want: "feat(scope):   "},
+		{title: "feat(scope):something", want: "feat(scope):something"},
+		{title: "feat: something\n wicked this way comes", want: "feat: something\n wicked this way comes"},
+		// recognized (non-standard) prefixes are trimmed, matching categorization
+		{title: "deps: bump foo to v2", recognized: []string{"deps"}, want: "bump foo to v2"},
+		{title: "deps(go)!: bump foo to v2", recognized: []string{"deps"}, want: "bump foo to v2"},
+		{title: "security: patch CVE-2026-0001", recognized: []string{"deps", "security"}, want: "patch CVE-2026-0001"},
+		// recognized matching is case-insensitive
+		{title: "Deps: bump foo", recognized: []string{"deps"}, want: "bump foo"},
+		{title: "deps: bump foo", recognized: []string{"Deps"}, want: "bump foo"},
+		// an unrecognized non-standard prefix is left intact even when a recognized set is given
+		{title: "wibble: do a thing", recognized: []string{"deps"}, want: "wibble: do a thing"},
+		// standard types are always trimmed regardless of the recognized set
+		{title: "feat: add a thing", recognized: []string{"deps"}, want: "add a thing"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			assert.Equal(t, tt.want, TrimConventionalCommitPrefix(tt.title, tt.recognized...))
+		})
+	}
+}

--- a/chronicle/release/description.go
+++ b/chronicle/release/description.go
@@ -10,9 +10,14 @@ type Description struct {
 	Notice           string             // manual note or summary that describes the changelog at a high level
 	Changes          change.Changes     // all issues and PRs that makeup this release
 	SupportedChanges []change.TypeTitle // the sections of the changelog and their display titles
-	PreviousRelease  *Release           // the release this changelog starts from; nil if since the beginning of history
-	Speculated       bool               // true when the version was inferred by the speculator
-	Trunk            *TrunkData         // optional, populated by summarizers that implement TrunkSummarizer
+
+	// ConventionalCommitTypes are the (possibly non-standard) conventional-commit
+	// type prefixes recognized for this changelog, used by encoders to strip the
+	// prefix from change display text consistently with how it was categorized.
+	ConventionalCommitTypes []string
+	PreviousRelease         *Release   // the release this changelog starts from; nil if since the beginning of history
+	Speculated              bool       // true when the version was inferred by the speculator
+	Trunk                   *TrunkData // optional, populated by summarizers that implement TrunkSummarizer
 
 	// raw evidence totals (pre-filter), surfaced for the summary report so it
 	// can show "N (M kept)" trailers. Populated by the worker after the

--- a/chronicle/release/output/encoders/markdown/encoder.go
+++ b/chronicle/release/output/encoders/markdown/encoder.go
@@ -7,9 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/leodido/go-conventionalcommits"
-	cc "github.com/leodido/go-conventionalcommits/parser"
-
 	"github.com/anchore/chronicle/chronicle/release"
 	"github.com/anchore/chronicle/chronicle/release/change"
 )
@@ -43,7 +40,7 @@ func (e *Encoder) Encode(w io.Writer, title string, d release.Description) error
 
 	funcMap := template.FuncMap{
 		"formatChangeSections": func(changes change.Changes) string {
-			return formatChangeSections(d.SupportedChanges, changes)
+			return formatChangeSections(d.SupportedChanges, changes, d.ConventionalCommitTypes)
 		},
 	}
 
@@ -66,27 +63,27 @@ func renderTitle(raw string, d release.Description) (string, error) {
 	return buf.String(), nil
 }
 
-func formatChangeSections(sections []change.TypeTitle, changes change.Changes) string {
+func formatChangeSections(sections []change.TypeTitle, changes change.Changes, recognizedTypes []string) string {
 	var result string
 	for _, section := range sections {
 		summaries := changes.ByChangeType(section.ChangeType)
 		if len(summaries) > 0 {
-			result += formatChangeSection(section.Title, summaries) + "\n"
+			result += formatChangeSection(section.Title, summaries, recognizedTypes) + "\n"
 		}
 	}
 	return strings.TrimRight(result, "\n")
 }
 
-func formatChangeSection(title string, summaries []change.Change) string {
+func formatChangeSection(title string, summaries []change.Change, recognizedTypes []string) string {
 	result := fmt.Sprintf("### %s\n\n", title)
 	for _, summary := range summaries {
-		result += formatSummary(summary)
+		result += formatSummary(summary, recognizedTypes)
 	}
 	return result
 }
 
-func formatSummary(summary change.Change) string {
-	result := removeConventionalCommitPrefix(strings.TrimSpace(summary.Text))
+func formatSummary(summary change.Change, recognizedTypes []string) string {
+	result := change.TrimConventionalCommitPrefix(strings.TrimSpace(summary.Text), recognizedTypes...)
 	result = fmt.Sprintf("- %s", result)
 	if endsWithPunctuation(result) {
 		result = result[:len(result)-1]
@@ -163,20 +160,4 @@ func endsWithPunctuation(s string) bool {
 		return false
 	}
 	return strings.Contains("!.?", s[len(s)-1:]) //nolint:gocritic
-}
-
-func removeConventionalCommitPrefix(s string) string {
-	res, err := cc.NewMachine(cc.WithTypes(conventionalcommits.TypesConventional)).Parse([]byte(s))
-	if err != nil || res == nil || (res != nil && !res.Ok()) {
-		// probably not a conventional commit
-		return s
-	}
-
-	// conventional commits always have a prefix and the message starts after the first ":"
-	fields := strings.SplitN(s, ":", 2)
-	if len(fields) == 2 {
-		return strings.TrimSpace(fields[1])
-	}
-
-	return s
 }

--- a/chronicle/release/output/encoders/markdown/encoder_test.go
+++ b/chronicle/release/output/encoders/markdown/encoder_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/chronicle/chronicle/release"
@@ -195,38 +194,35 @@ func Test_formatReferences(t *testing.T) {
 	}
 }
 
-func Test_removeConventionalCommitPrefix(t *testing.T) {
+func Test_formatSummary_trimsRecognizedPrefix(t *testing.T) {
 	tests := []struct {
-		name string
-		want string
+		name       string
+		text       string
+		recognized []string
+		want       string
 	}{
-		// positive cases
-		{name: "feat: add user authentication", want: "add user authentication"},
-		{name: "fix: resolve null pointer exception", want: "resolve null pointer exception"},
-		{name: "docs: update README", want: "update README"},
-		{name: "style: format code according to style guide", want: "format code according to style guide"},
-		{name: "refactor: extract reusable function", want: "extract reusable function"},
-		{name: "perf: optimize database queries", want: "optimize database queries"},
-		{name: "test: add unit tests", want: "add unit tests"},
-		{name: "build: update build process", want: "update build process"},
-		{name: "ci: configure Travis CI", want: "configure Travis CI"},
-		{name: "chore: perform maintenance tasks", want: "perform maintenance tasks"},
-		// positive case odd balls
-		{name: "chore: can end with punctuation.", want: "can end with punctuation."},
-		{name: "revert!: revert: previous: commit", want: "revert: previous: commit"},
-		{name: "feat(api)!: implement new: API endpoints", want: "implement new: API endpoints"},
-		{name: "feat!: add awesome new feature (closes #123)", want: "add awesome new feature (closes #123)"},
-		{name: "fix(ui): fix layout issue (fixes #456)", want: "fix layout issue (fixes #456)"},
-		// negative cases
-		{name: "reallycoolthing: is done!", want: "reallycoolthing: is done!"},
-		{name: "feature: is done!", want: "feature: is done!"},
-		{name: "feat(scope):   ", want: "feat(scope):   "},
-		{name: "feat(scope):something", want: "feat(scope):something"},
-		{name: "feat: something\n wicked this way comes", want: "feat: something\n wicked this way comes"},
+		{
+			name: "standard prefix trimmed without any recognized types",
+			text: "feat: add a thing",
+			want: "- add a thing\n",
+		},
+		{
+			name:       "non-standard recognized prefix is trimmed",
+			text:       "deps: bump foo to v2",
+			recognized: []string{"deps"},
+			want:       "- bump foo to v2\n",
+		},
+		{
+			name: "non-standard prefix is left intact when not recognized",
+			text: "deps: bump foo to v2",
+			want: "- deps: bump foo to v2\n",
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, removeConventionalCommitPrefix(tt.name), "removeConventionalCommitPrefix(%v)", tt.name)
+			got := formatSummary(change.Change{Text: tt.text}, tt.recognized)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/chronicle/release/output/encoders/slack/encoder.go
+++ b/chronicle/release/output/encoders/slack/encoder.go
@@ -11,9 +11,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/leodido/go-conventionalcommits"
-	cc "github.com/leodido/go-conventionalcommits/parser"
-
 	"github.com/anchore/chronicle/chronicle/release"
 	"github.com/anchore/chronicle/chronicle/release/change"
 )
@@ -38,7 +35,7 @@ func (e *Encoder) Encode(w io.Writer, title string, d release.Description) error
 		fmt.Fprintf(&out, "*%s*\n\n", escapeMrkdwn(resolvedTitle))
 	}
 
-	if sections := formatChangeSections(d.SupportedChanges, d.Changes); sections != "" {
+	if sections := formatChangeSections(d.SupportedChanges, d.Changes, d.ConventionalCommitTypes); sections != "" {
 		out.WriteString(sections)
 		out.WriteString("\n\n")
 	}
@@ -61,27 +58,27 @@ func renderTitle(raw string, d release.Description) (string, error) {
 	return buf.String(), nil
 }
 
-func formatChangeSections(sections []change.TypeTitle, changes change.Changes) string {
+func formatChangeSections(sections []change.TypeTitle, changes change.Changes, recognizedTypes []string) string {
 	var result string
 	for _, section := range sections {
 		summaries := changes.ByChangeType(section.ChangeType)
 		if len(summaries) > 0 {
-			result += formatChangeSection(section.Title, summaries) + "\n"
+			result += formatChangeSection(section.Title, summaries, recognizedTypes) + "\n"
 		}
 	}
 	return strings.TrimRight(result, "\n")
 }
 
-func formatChangeSection(title string, summaries []change.Change) string {
+func formatChangeSection(title string, summaries []change.Change, recognizedTypes []string) string {
 	result := fmt.Sprintf("*%s*\n", title)
 	for _, summary := range summaries {
-		result += formatSummary(summary)
+		result += formatSummary(summary, recognizedTypes)
 	}
 	return result
 }
 
-func formatSummary(summary change.Change) string {
-	text := removeConventionalCommitPrefix(strings.TrimSpace(summary.Text))
+func formatSummary(summary change.Change, recognizedTypes []string) string {
+	text := change.TrimConventionalCommitPrefix(strings.TrimSpace(summary.Text), recognizedTypes...)
 	if endsWithPunctuation(text) {
 		text = text[:len(text)-1]
 	}
@@ -174,20 +171,4 @@ func endsWithPunctuation(s string) bool {
 		return false
 	}
 	return strings.Contains("!.?", s[len(s)-1:]) //nolint:gocritic
-}
-
-func removeConventionalCommitPrefix(s string) string {
-	res, err := cc.NewMachine(cc.WithTypes(conventionalcommits.TypesConventional)).Parse([]byte(s))
-	if err != nil || res == nil || (res != nil && !res.Ok()) {
-		// probably not a conventional commit
-		return s
-	}
-
-	// conventional commits always have a prefix and the message starts after the first ":"
-	fields := strings.SplitN(s, ":", 2)
-	if len(fields) == 2 {
-		return strings.TrimSpace(fields[1])
-	}
-
-	return s
 }

--- a/chronicle/release/releasers/github/gh_pull_request.go
+++ b/chronicle/release/releasers/github/gh_pull_request.go
@@ -179,28 +179,27 @@ func prsWithoutOpenLinkedIssue() prFilter {
 	}
 }
 
-func prsWithLabel(labels ...string) prFilter {
-	return func(pr ghPullRequest, ctx ...*string) bool {
-		for _, targetLabel := range labels {
-			for _, l := range pr.Labels {
-				if l == targetLabel {
-					return true
-				}
-			}
-		}
-		setReason(ctx, "label:missing-required")
-		log.Tracef("PR #%d filtered out: missing required label", pr.Number)
-
-		return false
-	}
-}
-
 func prsWithoutLabels() prFilter {
 	return func(pr ghPullRequest, ctx ...*string) bool {
 		keep := len(pr.Labels) == 0
 		if !keep {
 			setReason(ctx, "labels:present")
 			log.Tracef("PR #%d filtered out: has labels", pr.Number)
+		}
+		return keep
+	}
+}
+
+// prsWithoutChangeType keeps only PRs that resolve to no change type. It guards
+// the unlabeled-PR path against double-counting PRs whose change type was
+// inferred from a conventional-commit title — those are carried by the standard
+// (typed) PR path instead.
+func prsWithoutChangeType(config Config) prFilter {
+	return func(pr ghPullRequest, ctx ...*string) bool {
+		keep := len(prChangeTypes(config, pr)) == 0
+		if !keep {
+			setReason(ctx, "change-type:inferred")
+			log.Tracef("PR #%d filtered out of unlabeled path: change type inferred from title", pr.Number)
 		}
 		return keep
 	}
@@ -219,7 +218,7 @@ func prsWithoutLinkedIssues() prFilter {
 
 func prsWithChangeTypes(config Config) prFilter {
 	return func(pr ghPullRequest, ctx ...*string) bool {
-		changeTypes := config.ChangeTypesByLabel.ChangeTypes(pr.Labels...)
+		changeTypes := prChangeTypes(config, pr)
 
 		keep := len(changeTypes) > 0
 		if !keep {

--- a/chronicle/release/releasers/github/gh_pull_request_test.go
+++ b/chronicle/release/releasers/github/gh_pull_request_test.go
@@ -166,41 +166,6 @@ func Test_prsBefore(t *testing.T) {
 	}
 }
 
-func Test_prsWithLabel(t *testing.T) {
-	tests := []struct {
-		name   string
-		pr     ghPullRequest
-		labels []string
-		keep   bool
-	}{
-		{
-			name: "matches on label",
-			labels: []string{
-				"positive",
-			},
-			pr: ghPullRequest{
-				Labels: []string{"something-else", "positive"},
-			},
-			keep: true,
-		},
-		{
-			name: "does not match on label",
-			labels: []string{
-				"positive",
-			},
-			pr: ghPullRequest{
-				Labels: []string{"something-else", "negative"},
-			},
-			keep: false,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.keep, prsWithLabel(test.labels...)(test.pr))
-		})
-	}
-}
-
 func Test_prsWithoutLabel(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/chronicle/release/releasers/github/summarizer.go
+++ b/chronicle/release/releasers/github/summarizer.go
@@ -38,6 +38,13 @@ type Config struct {
 	ChangeTypesByLabel              change.TypeSet
 	IssuesRequireLinkedPR           bool
 	ConsiderPRMergeCommits          bool
+
+	// InferChangeTypeFromTitle, when true, infers a change type from a PR's
+	// conventional-commit title prefix when the PR carries no change-type label.
+	InferChangeTypeFromTitle bool
+	// ChangeTypesByConventionalCommitType maps a conventional-commit prefix (e.g.
+	// "feat", "fix", or the "!" breaking marker) to a change type.
+	ChangeTypesByConventionalCommitType change.TypeSet
 }
 
 type Summarizer struct {
@@ -595,12 +602,9 @@ func uniqueIssuesFromPRs(prs []ghPullRequest) []ghIssue {
 }
 
 func changesFromStandardPRFilters(config Config, allMergedPRs []ghPullRequest, sinceTag, untilTag *git.Tag, includeCommits []string) []change.Change {
+	// the standard qualitative filters already keep only PRs that resolve to a
+	// change type (prsWithChangeTypes), so no further change-type filter is needed.
 	includedPRs := applyStandardPRFilters(allMergedPRs, config, sinceTag, untilTag, includeCommits)
-
-	beforeChangeTypeFilter := len(includedPRs)
-	var droppedNoChangeType []droppedPR
-	includedPRs, droppedNoChangeType = filterPRs(includedPRs, prsWithChangeTypes(config))
-	log.WithFields("kept", len(includedPRs), "dropped", len(droppedNoChangeType), "input", beforeChangeTypeFilter).Trace("PR change-type filter")
 
 	log.WithFields("count", len(includedPRs)).Info("PRs contributing to changelog")
 	logPRs(includedPRs)
@@ -608,10 +612,71 @@ func changesFromStandardPRFilters(config Config, allMergedPRs []ghPullRequest, s
 	return createChangesFromPRs(config, includedPRs)
 }
 
+// prChangeTypes resolves the change types for a PR. Explicit change-type labels
+// always win; otherwise, when enabled, the type is inferred from a
+// conventional-commit prefix in the PR title (e.g. "feat: ..." -> added-feature).
+// Returns nil when no type can be resolved.
+func prChangeTypes(config Config, pr ghPullRequest) []change.Type {
+	if types := config.ChangeTypesByLabel.ChangeTypes(pr.Labels...); len(types) > 0 {
+		return types
+	}
+
+	if !config.InferChangeTypeFromTitle {
+		return nil
+	}
+
+	ccType, breaking, ok := change.ParseConventionalCommit(pr.Title)
+	if !ok {
+		return nil
+	}
+
+	// a breaking marker ("!") takes precedence over the base type when it is
+	// mapped (e.g. "feat!: ..." -> breaking-feature rather than added-feature).
+	if breaking {
+		if types := config.ChangeTypesByConventionalCommitType.ChangeTypes(change.BreakingChangePrefix); len(types) > 0 {
+			return types
+		}
+	}
+
+	// conventional-commit types are matched case-insensitively; the parser
+	// normalizes to lowercase and configured prefixes are keyed lowercase.
+	return config.ChangeTypesByConventionalCommitType.ChangeTypes(strings.ToLower(ccType))
+}
+
+// prHasUnmappedBreakingMarker reports whether a PR title carries a
+// conventional-commit breaking marker ("!") that maps to no change type. When
+// true the breaking signal is silently dropped — the PR is categorized by its
+// base type (e.g. "feat!: ..." -> added-feature) or not at all — so callers
+// warn to surface the likely-missing breaking-change mapping.
+//
+// An explicit change-type label short-circuits title inference entirely (see
+// prChangeTypes), so a labeled PR's title is never consulted; warning about its
+// breaking marker would be misleading (mapping "!" would not change the
+// outcome). Only PRs that fall through to title inference are considered.
+func prHasUnmappedBreakingMarker(config Config, pr ghPullRequest) bool {
+	if !config.InferChangeTypeFromTitle {
+		return false
+	}
+	if len(config.ChangeTypesByLabel.ChangeTypes(pr.Labels...)) > 0 {
+		return false
+	}
+	_, breaking, ok := change.ParseConventionalCommit(pr.Title)
+	if !ok || !breaking {
+		return false
+	}
+	return len(config.ChangeTypesByConventionalCommitType.ChangeTypes(change.BreakingChangePrefix)) == 0
+}
+
 func createChangesFromPRs(config Config, prs []ghPullRequest) []change.Change {
 	var summaries []change.Change
 	for _, pr := range prs {
-		changeTypes := config.ChangeTypesByLabel.ChangeTypes(pr.Labels...)
+		if prHasUnmappedBreakingMarker(config, pr) {
+			log.Warnf("PR #%d title %q carries a breaking-change marker (%q) but no change type maps it; "+
+				"the change will not be treated as breaking (add %q to a change type's prefixes to fix)",
+				pr.Number, pr.Title, change.BreakingChangePrefix, change.BreakingChangePrefix)
+		}
+
+		changeTypes := prChangeTypes(config, pr)
 
 		if len(changeTypes) == 0 {
 			changeTypes = change.UnknownTypes
@@ -687,6 +752,9 @@ func changesFromUnlabeledPRs(config Config, allMergedPRs []ghPullRequest, sinceT
 	filters := []prFilter{
 		prsWithoutLabels(),
 		prsWithoutLinkedIssues(),
+		// a PR whose change type was inferred from its title is carried by the
+		// standard (typed) PR path; exclude it here so it isn't counted twice.
+		prsWithoutChangeType(config),
 	}
 
 	filters = append(filters, standardChronologicalPrFilters(config, sinceTag, untilTag, includeCommits)...)
@@ -826,7 +894,9 @@ func standardChronologicalIssueFilters(sinceTag, untilTag *git.Tag) (filters []i
 func standardQualitativePrFilters(config Config) []prFilter {
 	// this represents the traits we wish to filter down to (not out).
 	return []prFilter{
-		prsWithLabel(config.ChangeTypesByLabel.Names()...),
+		// keep PRs that resolve to a change type, either from a change-type label
+		// or (when enabled) an inferred conventional-commit title prefix.
+		prsWithChangeTypes(config),
 		prsWithoutLabel(config.ExcludeLabels...),
 		// Merged PRs linked to closed issues should be hidden so that the closed issue title takes precedence over the pr title
 		prsWithoutClosedLinkedIssue(),

--- a/chronicle/release/releasers/github/summarizer_test.go
+++ b/chronicle/release/releasers/github/summarizer_test.go
@@ -373,6 +373,15 @@ func Test_prFilters(t *testing.T) {
 		MergeCommit: "made-up-commit-hash",
 	}
 
+	// no change-type label, but a conventional-commit title that resolves to a
+	// change type only when title inference is enabled.
+	prConventionalCommitNoLabel := ghPullRequest{
+		Title:       "feat: pr with conventional-commit title and no label",
+		Number:      15,
+		MergedAt:    timeAfter,
+		MergeCommit: mergeCommit1,
+	}
+
 	input := []ghPullRequest{
 		// keep
 		prBugAfterLastRelease,
@@ -446,6 +455,32 @@ func Test_prFilters(t *testing.T) {
 				prFeatureAfterEndTag,
 				prFeatureAfterEndTagAndMergeRange,
 			},
+		},
+		{
+			name:  "inference off drops unlabeled conventional-commit PR",
+			since: sinceTag,
+			config: Config{
+				ChangeTypesByLabel:                  changeTypeSet,
+				ChangeTypesByConventionalCommitType: change.TypeSet{"feat": feature},
+				InferChangeTypeFromTitle:            false,
+				ConsiderPRMergeCommits:              false,
+			},
+			inputPrs:    []ghPullRequest{prBugAfterLastRelease, prConventionalCommitNoLabel},
+			commits:     allMergeCommits,
+			expectedPrs: []ghPullRequest{prBugAfterLastRelease},
+		},
+		{
+			name:  "inference on keeps unlabeled conventional-commit PR",
+			since: sinceTag,
+			config: Config{
+				ChangeTypesByLabel:                  changeTypeSet,
+				ChangeTypesByConventionalCommitType: change.TypeSet{"feat": feature},
+				InferChangeTypeFromTitle:            true,
+				ConsiderPRMergeCommits:              false,
+			},
+			inputPrs:    []ghPullRequest{prBugAfterLastRelease, prConventionalCommitNoLabel},
+			commits:     allMergeCommits,
+			expectedPrs: []ghPullRequest{prBugAfterLastRelease, prConventionalCommitNoLabel},
 		},
 	}
 
@@ -1042,6 +1077,50 @@ func Test_changesFromUnlabeledPRs(t *testing.T) {
 				},
 			},
 		},
+		{
+			// with title inference on, an unlabeled PR whose change type is inferred
+			// from its conventional-commit title is carried by the standard (typed)
+			// path, so it must be excluded here to avoid double-counting.
+			name: "excludes unlabeled PR with inferable conventional-commit title",
+			config: Config{
+				Host:                     "some-host",
+				InferChangeTypeFromTitle: true,
+				ChangeTypesByConventionalCommitType: change.TypeSet{
+					"feat": change.NewType("added-feature", change.SemVerMinor),
+				},
+			},
+			inputPrs: []ghPullRequest{
+				// filter: change type inferred from title
+				{
+					MergedAt: timeStart,
+					Title:    "feat: shiny new thing",
+					Number:   8,
+					Author:   "cc-author",
+					URL:      "cc-url",
+				},
+				// keep: not a conventional commit
+				prWithoutLabels,
+			},
+			expectedChanges: []change.Change{
+				{
+					Text:        "pr without labels",
+					ChangeTypes: change.UnknownTypes,
+					Timestamp:   timeStart,
+					References: []change.Reference{
+						{
+							Text: "#6",
+							URL:  "some-url",
+						},
+						{
+							Text: "@some-author",
+							URL:  "https://some-host/some-author",
+						},
+					},
+					EntryType: "githubPR",
+					Entry:     prWithoutLabels,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1429,6 +1508,194 @@ func TestSummarizer_ChangesURL(t *testing.T) {
 
 			got := s.ChangesURL(tt.sinceRef, tt.untilRef)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_prChangeTypes(t *testing.T) {
+	feature := change.NewType("added-feature", change.SemVerMinor)
+	bugFix := change.NewType("bug-fix", change.SemVerPatch)
+	breaking := change.NewType("breaking-feature", change.SemVerMajor)
+
+	labelSet := change.TypeSet{
+		"enhancement": feature,
+		"bug":         bugFix,
+	}
+	prefixSet := change.TypeSet{
+		"feat":                      feature,
+		"fix":                       bugFix,
+		change.BreakingChangePrefix: breaking,
+	}
+
+	config := Config{
+		InferChangeTypeFromTitle:            true,
+		ChangeTypesByLabel:                  labelSet,
+		ChangeTypesByConventionalCommitType: prefixSet,
+	}
+
+	tests := []struct {
+		name   string
+		config Config
+		pr     ghPullRequest
+		want   []change.Type
+	}{
+		{
+			name:   "label resolves change type",
+			config: config,
+			pr:     ghPullRequest{Title: "anything", Labels: []string{"bug"}},
+			want:   []change.Type{bugFix},
+		},
+		{
+			name:   "label wins over conventional-commit title",
+			config: config,
+			pr:     ghPullRequest{Title: "feat: add a thing", Labels: []string{"bug"}},
+			want:   []change.Type{bugFix},
+		},
+		{
+			name:   "infer from feat title when unlabeled",
+			config: config,
+			pr:     ghPullRequest{Title: "feat: add a thing"},
+			want:   []change.Type{feature},
+		},
+		{
+			name:   "infer from fix title when label is not a change-type label",
+			config: config,
+			pr:     ghPullRequest{Title: "fix: squash a bug", Labels: []string{"size/L"}},
+			want:   []change.Type{bugFix},
+		},
+		{
+			name:   "breaking marker takes precedence over base type",
+			config: config,
+			pr:     ghPullRequest{Title: "feat!: drop legacy API"},
+			want:   []change.Type{breaking},
+		},
+		{
+			// when "!" is not mapped, a breaking PR falls back to its base type.
+			name: "breaking marker falls back to base type when unmapped",
+			config: Config{
+				InferChangeTypeFromTitle:            true,
+				ChangeTypesByLabel:                  labelSet,
+				ChangeTypesByConventionalCommitType: change.TypeSet{"feat": feature},
+			},
+			pr:   ghPullRequest{Title: "feat!: drop legacy API"},
+			want: []change.Type{feature},
+		},
+		{
+			// the parser lowercases the type, so an uppercase title still resolves
+			// against the lowercase-keyed prefix set.
+			name:   "inference is case-insensitive on the title type",
+			config: config,
+			pr:     ghPullRequest{Title: "Feat: add a thing"},
+			want:   []change.Type{feature},
+		},
+		{
+			name:   "unmapped conventional-commit type yields nothing",
+			config: config,
+			pr:     ghPullRequest{Title: "docs: update the readme"},
+			want:   nil,
+		},
+		{
+			name:   "non-conventional title yields nothing",
+			config: config,
+			pr:     ghPullRequest{Title: "Bump foo to v2"},
+			want:   nil,
+		},
+		{
+			name: "inference disabled falls back to labels only",
+			config: Config{
+				InferChangeTypeFromTitle:            false,
+				ChangeTypesByLabel:                  labelSet,
+				ChangeTypesByConventionalCommitType: prefixSet,
+			},
+			pr:   ghPullRequest{Title: "feat: add a thing"},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := prChangeTypes(tt.config, tt.pr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_prHasUnmappedBreakingMarker(t *testing.T) {
+	feature := change.NewType("added-feature", change.SemVerMinor)
+	breaking := change.NewType("breaking-feature", change.SemVerMajor)
+
+	withBreaking := Config{
+		InferChangeTypeFromTitle: true,
+		ChangeTypesByConventionalCommitType: change.TypeSet{
+			"feat":                      feature,
+			change.BreakingChangePrefix: breaking,
+		},
+	}
+	withoutBreaking := Config{
+		InferChangeTypeFromTitle:            true,
+		ChangeTypesByLabel:                  change.TypeSet{"bug": change.NewType("bug-fix", change.SemVerPatch)},
+		ChangeTypesByConventionalCommitType: change.TypeSet{"feat": feature},
+	}
+
+	tests := []struct {
+		name   string
+		config Config
+		pr     ghPullRequest
+		want   bool
+	}{
+		{
+			name:   "breaking marker with no breaking mapping warns (base type mapped)",
+			config: withoutBreaking,
+			pr:     ghPullRequest{Title: "feat!: drop legacy API"},
+			want:   true,
+		},
+		{
+			name:   "breaking marker with no breaking mapping warns (base type also unmapped)",
+			config: withoutBreaking,
+			pr:     ghPullRequest{Title: "chore!: drop legacy API"},
+			want:   true,
+		},
+		{
+			name:   "breaking marker mapped does not warn",
+			config: withBreaking,
+			pr:     ghPullRequest{Title: "feat!: drop legacy API"},
+			want:   false,
+		},
+		{
+			// an explicit change-type label short-circuits title inference, so the
+			// title (and its breaking marker) is never consulted — warning would be
+			// misleading.
+			name:   "change-type label short-circuits inference, no warning",
+			config: withoutBreaking,
+			pr:     ghPullRequest{Title: "feat!: drop legacy API", Labels: []string{"bug"}},
+			want:   false,
+		},
+		{
+			name:   "non-breaking conventional commit does not warn",
+			config: withoutBreaking,
+			pr:     ghPullRequest{Title: "feat: add a thing"},
+			want:   false,
+		},
+		{
+			name:   "non-conventional title does not warn",
+			config: withoutBreaking,
+			pr:     ghPullRequest{Title: "Bump foo to v2"},
+			want:   false,
+		},
+		{
+			name: "inference disabled does not warn",
+			config: Config{
+				InferChangeTypeFromTitle:            false,
+				ChangeTypesByConventionalCommitType: change.TypeSet{"feat": feature},
+			},
+			pr:   ghPullRequest{Title: "feat!: drop legacy API"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, prHasUnmappedBreakingMarker(tt.config, tt.pr))
 		})
 	}
 }

--- a/cmd/chronicle/cli/commands/create_github_worker.go
+++ b/cmd/chronicle/cli/commands/create_github_worker.go
@@ -86,6 +86,12 @@ func createChangelogFromGithub(appConfig *createConfig) (*release.Release, *rele
 		return startRelease, description, err
 	}
 
+	// surface the configured conventional-commit prefixes so encoders can trim
+	// them from change display text consistently with how they were categorized.
+	if description != nil {
+		description.ConventionalCommitTypes = getGithubConventionalCommitTypes(appConfig)
+	}
+
 	// resolve range slots from what we now know about each end of the range.
 	resolveRangeSlots(rng, gitter, appConfig.SinceTag, untilTag, description)
 
@@ -241,6 +247,23 @@ func checkTrunkPrerequisites(appConfig *createConfig) error {
 		}
 	}
 	return nil
+}
+
+// getGithubConventionalCommitTypes collects every conventional-commit type
+// prefix configured across all change types (excluding the breaking "!" marker,
+// which is not a type token). Encoders use these to trim non-standard prefixes
+// from display text.
+func getGithubConventionalCommitTypes(appConfig *createConfig) []string {
+	var prefixes []string
+	for _, c := range appConfig.Github.Changes {
+		for _, p := range c.Prefixes {
+			if p == change.BreakingChangePrefix {
+				continue
+			}
+			prefixes = append(prefixes, p)
+		}
+	}
+	return prefixes
 }
 
 func getGithubSupportedChanges(appConfig *createConfig) []change.TypeTitle {

--- a/cmd/chronicle/cli/options/github.go
+++ b/cmd/chronicle/cli/options/github.go
@@ -1,6 +1,8 @@
 package options
 
 import (
+	"strings"
+
 	"github.com/anchore/chronicle/chronicle/release/change"
 	"github.com/anchore/chronicle/chronicle/release/releasers/github"
 	"github.com/anchore/clio"
@@ -18,6 +20,7 @@ type GithubSummarizer struct {
 	IncludeUnlabeledPRs             bool           `yaml:"include-unlabeled-prs" json:"include-unlabeled-prs" mapstructure:"include-unlabeled-prs"`
 	IssuesRequireLinkedPR           bool           `yaml:"issues-require-linked-prs" json:"issues-require-linked-prs" mapstructure:"issues-require-linked-prs"`
 	ConsiderPRMergeCommits          bool           `yaml:"consider-pr-merge-commits" json:"consider-pr-merge-commits" mapstructure:"consider-pr-merge-commits"`
+	InferChangeTypeFromTitle        bool           `yaml:"infer-change-type-from-title" json:"infer-change-type-from-title" mapstructure:"infer-change-type-from-title"`
 	Changes                         []GithubChange `yaml:"changes" json:"changes" mapstructure:"changes"`
 }
 
@@ -33,6 +36,7 @@ func (c *GithubSummarizer) DescribeFields(descriptions clio.FieldDescriptionSet)
 	descriptions.Add(&c.IncludeUnlabeledPRs, "include PRs without labels or linked issues")
 	descriptions.Add(&c.IssuesRequireLinkedPR, "only include issues with linked PRs")
 	descriptions.Add(&c.ConsiderPRMergeCommits, "include merge commits")
+	descriptions.Add(&c.InferChangeTypeFromTitle, "infer the change type from a conventional-commit PR title when no change-type label is present")
 	descriptions.Add(&c.Changes, "configure change types and their associated labels")
 }
 
@@ -43,6 +47,7 @@ type GithubChange struct {
 	Title      string   `yaml:"title" json:"title" mapstructure:"title"`
 	SemVerKind string   `yaml:"semver-field" json:"semver-field" mapstructure:"semver-field"`
 	Labels     []string `yaml:"labels" json:"labels" mapstructure:"labels"`
+	Prefixes   []string `yaml:"prefixes" json:"prefixes" mapstructure:"prefixes"`
 }
 
 func (c *GithubChange) DescribeFields(descriptions clio.FieldDescriptionSet) {
@@ -50,32 +55,41 @@ func (c *GithubChange) DescribeFields(descriptions clio.FieldDescriptionSet) {
 	descriptions.Add(&c.Title, "title to display in the changelog for this change type")
 	descriptions.Add(&c.SemVerKind, "semver field affected: major, minor, or patch")
 	descriptions.Add(&c.Labels, "GitHub labels that map to this change type")
+	descriptions.Add(&c.Prefixes, `conventional-commit type prefixes that map to this change type (e.g. "feat", "fix"); use "!" for the breaking-change marker`)
 }
 
 var _ clio.FieldDescriber = (*GithubChange)(nil)
 
 func (c GithubSummarizer) ToGithubConfig() github.Config {
 	typeSet := make(change.TypeSet)
+	prefixSet := make(change.TypeSet)
 	for _, c := range c.Changes {
 		k := change.ParseSemVerKind(c.SemVerKind)
 		t := change.NewType(c.Type, k)
 		for _, l := range c.Labels {
 			typeSet[l] = t
 		}
+		for _, p := range c.Prefixes {
+			// conventional-commit types are matched case-insensitively against the
+			// (lowercase-normalized) parsed PR title type, so key on the lowercase form.
+			prefixSet[strings.ToLower(p)] = t
+		}
 	}
 	return github.Config{
-		Host:                            c.Host,
-		IncludeIssuePRAuthors:           c.IncludeIssuePRAuthors,
-		IncludeIssuePRs:                 c.IncludeIssuePRs,
-		IncludeIssues:                   c.IncludeIssues,
-		IncludeIssuesClosedAsNotPlanned: c.IncludeIssuesClosedAsNotPlanned,
-		IncludePRs:                      c.IncludePRs,
-		IncludeUnlabeledIssues:          c.IncludeUnlabeledIssues,
-		IncludeUnlabeledPRs:             c.IncludeUnlabeledPRs,
-		ExcludeLabels:                   c.ExcludeLabels,
-		IssuesRequireLinkedPR:           c.IssuesRequireLinkedPR,
-		ConsiderPRMergeCommits:          c.ConsiderPRMergeCommits,
-		ChangeTypesByLabel:              typeSet,
+		Host:                                c.Host,
+		IncludeIssuePRAuthors:               c.IncludeIssuePRAuthors,
+		IncludeIssuePRs:                     c.IncludeIssuePRs,
+		IncludeIssues:                       c.IncludeIssues,
+		IncludeIssuesClosedAsNotPlanned:     c.IncludeIssuesClosedAsNotPlanned,
+		IncludePRs:                          c.IncludePRs,
+		IncludeUnlabeledIssues:              c.IncludeUnlabeledIssues,
+		IncludeUnlabeledPRs:                 c.IncludeUnlabeledPRs,
+		ExcludeLabels:                       c.ExcludeLabels,
+		IssuesRequireLinkedPR:               c.IssuesRequireLinkedPR,
+		ConsiderPRMergeCommits:              c.ConsiderPRMergeCommits,
+		InferChangeTypeFromTitle:            c.InferChangeTypeFromTitle,
+		ChangeTypesByLabel:                  typeSet,
+		ChangeTypesByConventionalCommitType: prefixSet,
 	}
 }
 
@@ -84,6 +98,7 @@ func DefaultGithubSimmarizer() GithubSummarizer {
 		Host:                            "github.com",
 		IssuesRequireLinkedPR:           false,
 		ConsiderPRMergeCommits:          true,
+		InferChangeTypeFromTitle:        true,
 		IncludePRs:                      true,
 		IncludeIssuePRAuthors:           true,
 		IncludeIssuePRs:                 true,
@@ -103,18 +118,28 @@ func DefaultGithubSimmarizer() GithubSummarizer {
 				Type:       "added-feature",
 				Title:      "Added Features",
 				Labels:     []string{"enhancement", "feature", "minor"},
+				Prefixes:   []string{"feat"},
 				SemVerKind: change.SemVerMinor.String(),
 			},
 			{
 				Type:       "bug-fix",
 				Title:      "Bug Fixes",
 				Labels:     []string{"bug", "fix", "bug-fix", "patch"},
+				Prefixes:   []string{"fix"},
+				SemVerKind: change.SemVerPatch.String(),
+			},
+			{
+				Type:       "performance",
+				Title:      "Performance",
+				Labels:     []string{"performance", "perf"},
+				Prefixes:   []string{"perf"},
 				SemVerKind: change.SemVerPatch.String(),
 			},
 			{
 				Type:       "breaking-feature",
 				Title:      "Breaking Changes",
 				Labels:     []string{"breaking", "backwards-incompatible", "breaking-change", "breaking-feature", "major"},
+				Prefixes:   []string{change.BreakingChangePrefix},
 				SemVerKind: change.SemVerMajor.String(),
 			},
 			{

--- a/cmd/chronicle/cli/options/github_test.go
+++ b/cmd/chronicle/cli/options/github_test.go
@@ -1,0 +1,45 @@
+package options
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/chronicle/chronicle/release/change"
+)
+
+func TestGithubSummarizer_ToGithubConfig_prefixes(t *testing.T) {
+	feature := change.NewType("added-feature", change.SemVerMinor)
+	breaking := change.NewType("breaking-feature", change.SemVerMajor)
+
+	summarizer := GithubSummarizer{
+		InferChangeTypeFromTitle: true,
+		Changes: []GithubChange{
+			{
+				Type:       "added-feature",
+				SemVerKind: change.SemVerMinor.String(),
+				Labels:     []string{"enhancement"},
+				// mixed case to exercise normalization
+				Prefixes: []string{"feat", "Feature"},
+			},
+			{
+				Type:       "breaking-feature",
+				SemVerKind: change.SemVerMajor.String(),
+				Prefixes:   []string{change.BreakingChangePrefix},
+			},
+		},
+	}
+
+	cfg := summarizer.ToGithubConfig()
+
+	assert.True(t, cfg.InferChangeTypeFromTitle)
+
+	// prefix keys are lowercased so they match the (lowercase-normalized) parsed
+	// PR title type, while the breaking marker is preserved verbatim.
+	want := change.TypeSet{
+		"feat":                      feature,
+		"feature":                   feature,
+		change.BreakingChangePrefix: breaking,
+	}
+	assert.Equal(t, want, cfg.ChangeTypesByConventionalCommitType)
+}


### PR DESCRIPTION
Closes #57 

Today a merged PR only lands in a changelog section if it has a matching label. This adds a fallback: when a PR has no change-type label, chronicle can read a [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/#specification) prefix from the title (`feat: ...`, `fix: ...`, `perf!: ...`) and categorize it from that. Labels still win when present.

So a PR titled `feat: add SBOM caching` with no labels, which used to fall through to the unlabeled bucket, now shows up where you'd expect with the prefix stripped:

```markdown
### Added Features

- add SBOM caching [#123](https://github.com/you/repo/pull/123) [@someone]
```

A `feat!:` (or `fix(api)!:`) title counts as a breaking change and bumps major, same as a breaking label.

Configuration changes:

- `github.infer-change-type-from-title` (bool, default `true`, env `CHRONICLE_GITHUB_INFER_CHANGE_TYPE_FROM_TITLE`) is the on/off switch. Set it to `false` for the old label-only behavior.

- `github.changes[].prefixes` (list of strings) maps conventional-commit type prefixes to a section. Matched case-insensitively, PR-only, and can't be set via env var since it's part of the `changes` list. Use `!` to match the breaking-change marker.

```yaml
github:
  infer-change-type-from-title: true
  changes:
    - name: added-feature
      title: Added Features
      semver-field: minor
      labels: [enhancement, feature, minor]
      prefixes: [feat]
    - name: performance        # new default section
      title: Performance
      semver-field: patch
      labels: [performance, perf]
      prefixes: [perf]
    - name: breaking-feature
      title: Breaking Changes
      semver-field: major
      labels: [breaking, breaking-change]
      prefixes: ["!"]          # matches feat!: / fix!: / etc.
```

Defaults now wire up `feat`/`fix`/`perf`/`!` out of the box and add a new Performance section.

A couple things to know. If a title has a `!` marker but no section declares the `!` prefix, chronicle logs a warning and falls back to the base type so the breaking change doesn't silently bump major. And since the switch defaults to `true`, repos already using conventional-commit titles may see previously-uncategorized PRs start showing up in sections (and nudging the speculated version); flip it off to keep the old behavior.
