### PR TITLE
Consider commits that relate to the release (not entire history)

### DIFF
--- a/chronicle/event/group.go
+++ b/chronicle/event/group.go
@@ -14,6 +14,10 @@ const (
 	SlotRunning
 	SlotResolved
 	SlotFailed
+	// SlotSkipped marks work that was intentionally not performed (e.g. the
+	// analysis short-circuited before this step was needed). Distinct from
+	// Resolved so the UI can show "skipped" rather than a completed count.
+	SlotSkipped
 )
 
 // GroupSlotInit is the configuration for one slot at group-construction time.

--- a/chronicle/event/parsers_test.go
+++ b/chronicle/event/parsers_test.go
@@ -281,6 +281,7 @@ func TestNilSafety(t *testing.T) {
 	var l *Leaf
 	require.NotPanics(t, func() { l.Resolve("1", "n") })
 	require.NotPanics(t, func() { l.Fail(nil) })
+	require.NotPanics(t, func() { l.Skip() })
 	require.NotPanics(t, func() { l.Start() })
 	require.NotPanics(t, func() { l.SetStage("x") })
 	require.Equal(t, "", l.Name())
@@ -288,4 +289,29 @@ func TestNilSafety(t *testing.T) {
 	require.Equal(t, "", l.Note())
 	require.Equal(t, SlotPending, l.State())
 	require.Nil(t, l.Err())
+}
+
+func TestLeaf_Skip(t *testing.T) {
+	tr := NewTree("evidence", []string{"issues"})
+	l := tr.Leaf("issues")
+
+	l.Skip()
+
+	require.Equal(t, SlotSkipped, l.State())
+	// a skipped leaf carries no count or note
+	require.Equal(t, "", l.Count())
+	require.Equal(t, "", l.Note())
+}
+
+func TestTree_Close_preservesSkipped(t *testing.T) {
+	// Close() promotes pending/running leaves to resolved, but must leave an
+	// explicitly skipped leaf untouched.
+	tr := NewTree("evidence", []string{"commits", "issues"})
+	tr.Leaf("commits").Start()
+	tr.Leaf("issues").Skip()
+
+	tr.Close()
+
+	require.Equal(t, SlotResolved, tr.Leaf("commits").State())
+	require.Equal(t, SlotSkipped, tr.Leaf("issues").State())
 }

--- a/chronicle/event/tree.go
+++ b/chronicle/event/tree.go
@@ -171,6 +171,19 @@ func (l *Leaf) Resolve(count, note string) {
 	l.SetCompleted()
 }
 
+// Skip marks the leaf as intentionally not run — e.g. the analysis
+// short-circuited before this fetch was needed. The leaf carries no count; the
+// UI renders a distinct "skipped" state rather than a completed value.
+func (l *Leaf) Skip() {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	l.state = SlotSkipped
+	l.mu.Unlock()
+	l.SetCompleted()
+}
+
 // Fail flips the leaf to the failed state.
 func (l *Leaf) Fail(err error) {
 	if l == nil {

--- a/chronicle/release/releasers/github/summarizer.go
+++ b/chronicle/release/releasers/github/summarizer.go
@@ -69,6 +69,12 @@ type Summarizer struct {
 	issuesKept        int
 	associatedCommits int
 
+	// detailSkipped is set when the most recent Changes() call short-circuited
+	// before fetching issues and PRs because the scope held no commits. The
+	// worker reads it to mark those evidence leaves as skipped rather than
+	// resolved-with-zero.
+	detailSkipped bool
+
 	// optional UI leaves plumbed in by SetEvidenceLeaves. P3 stores them for
 	// P4 to use; this code does not yet update them.
 	commitsLeaf *event.Leaf
@@ -141,6 +147,17 @@ func (s *Summarizer) AssociatedCommits() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.associatedCommits
+}
+
+// DetailFetchSkipped reports whether the most recent Changes() call skipped the
+// issue and PR fetches because the scope contained no commits.
+func (s *Summarizer) DetailFetchSkipped() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.detailSkipped
 }
 
 // changeScope is used to describe the start and end of a changes made in a repo.
@@ -276,7 +293,42 @@ func (s *Summarizer) Changes(sinceRef, untilRef string) ([]change.Change, error)
 
 	logChangeScope(*scope, s.config.ConsiderPRMergeCommits)
 
+	// short-circuit: when merge commits gate the changelog and the resolved
+	// range contains none (e.g. HEAD sits exactly on the previous release), no
+	// PR or issue can be attributed to this release — skip the GitHub API
+	// fetches entirely and report an empty changelog.
+	if s.scopeHasNoCommits(*scope) {
+		log.Info("no commits in scope; skipping issue and pull request retrieval")
+		s.recordEmptyEvidence()
+		return nil, nil
+	}
+
 	return s.changes(*scope)
+}
+
+// scopeHasNoCommits reports whether the resolved range provably contains no
+// commits. This is only meaningful when ConsiderPRMergeCommits is enabled,
+// since that is the only mode in which the commit range is computed; in
+// timestamp-only mode scope.Commits is always empty and must not be treated as
+// a signal to short-circuit.
+func (s *Summarizer) scopeHasNoCommits(scope changeScope) bool {
+	return s.config.ConsiderPRMergeCommits && len(scope.Commits) == 0
+}
+
+// recordEmptyEvidence zeroes the evidence totals captured for the summary
+// report and flags that the issue/PR fetches were skipped. Used by the
+// no-commits short-circuit so the worker reports a skipped state rather than
+// stale values or a misleading resolved-with-zero.
+func (s *Summarizer) recordEmptyEvidence() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.commitTotal = 0
+	s.prTotal = 0
+	s.issueTotal = 0
+	s.prsKept = 0
+	s.issuesKept = 0
+	s.associatedCommits = 0
+	s.detailSkipped = true
 }
 
 func (s *Summarizer) getChangeScope(sinceRef, untilRef string) (*changeScope, error) {
@@ -372,6 +424,7 @@ func (s *Summarizer) changes(scope changeScope) ([]change.Change, error) {
 	// under the lock rather than repeatedly inside the goroutines below.
 	s.mu.Lock()
 	s.commitTotal = len(scope.Commits)
+	s.detailSkipped = false
 	prsLeaf := s.prsLeaf
 	issuesLeaf := s.issuesLeaf
 	s.mu.Unlock()

--- a/chronicle/release/releasers/github/summarizer_test.go
+++ b/chronicle/release/releasers/github/summarizer_test.go
@@ -1370,6 +1370,91 @@ func TestSummarizer_getChangeScope(t *testing.T) {
 	}
 }
 
+func TestSummarizer_scopeHasNoCommits(t *testing.T) {
+	tests := []struct {
+		name   string
+		config Config
+		scope  changeScope
+		want   bool
+	}{
+		{
+			name:   "merge-commit mode with no commits short-circuits",
+			config: Config{ConsiderPRMergeCommits: true},
+			scope:  changeScope{Commits: nil},
+			want:   true,
+		},
+		{
+			name:   "merge-commit mode with commits does not short-circuit",
+			config: Config{ConsiderPRMergeCommits: true},
+			scope:  changeScope{Commits: []string{"abc123"}},
+			want:   false,
+		},
+		{
+			// timestamp-only mode never populates Commits, so an empty slice must
+			// not be read as "no changes" — that would skip every changelog.
+			name:   "timestamp-only mode never short-circuits",
+			config: Config{ConsiderPRMergeCommits: false},
+			scope:  changeScope{Commits: nil},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Summarizer{config: tt.config}
+			require.Equal(t, tt.want, s.scopeHasNoCommits(tt.scope))
+		})
+	}
+}
+
+func TestSummarizer_Changes_noCommitsShortCircuit(t *testing.T) {
+	testTime := time.Now()
+
+	gitter, err := git.New("testdata/repos/v0.2.0-repo")
+	require.NoError(t, err)
+	gitter = mockGitter{timestamp: testTime, Interface: gitter}
+
+	s, err := NewSummarizer(gitter, Config{ConsiderPRMergeCommits: true})
+	require.NoError(t, err)
+	s.releaseFetcher = func(_, _, tag string) (*ghRelease, error) {
+		return &ghRelease{Tag: tag, Date: testTime, IsLatest: true}, nil
+	}
+
+	// since == until: HEAD sits exactly on the release tag, so the range holds
+	// no commits. The short-circuit must return an empty changelog without
+	// reaching the GitHub API (this test runs without network access; a missed
+	// short-circuit would attempt a fetch and fail).
+	changes, err := s.Changes("v0.2.0", "v0.2.0")
+	require.NoError(t, err)
+	require.Empty(t, changes)
+
+	prs, issues, commits := s.EvidenceTotals()
+	require.Zero(t, prs)
+	require.Zero(t, issues)
+	require.Zero(t, commits)
+}
+
+func TestSummarizer_Trunk_noCommitsShortCircuit(t *testing.T) {
+	testTime := time.Now()
+
+	gitter, err := git.New("testdata/repos/v0.2.0-repo")
+	require.NoError(t, err)
+	gitter = mockGitter{timestamp: testTime, Interface: gitter}
+
+	s, err := NewSummarizer(gitter, Config{ConsiderPRMergeCommits: true})
+	require.NoError(t, err)
+	s.releaseFetcher = func(_, _, tag string) (*ghRelease, error) {
+		return &ghRelease{Tag: tag, Date: testTime, IsLatest: true}, nil
+	}
+
+	// same since==until range as above: an empty commit set must yield an empty
+	// trunk view without any GitHub API fetch.
+	data, err := s.Trunk("v0.2.0", "v0.2.0")
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.Empty(t, data.Commits)
+}
+
 type mockGitter struct {
 	timestamp time.Time
 	git.Interface

--- a/chronicle/release/releasers/github/trunk.go
+++ b/chronicle/release/releasers/github/trunk.go
@@ -42,6 +42,13 @@ func (s *Summarizer) Trunk(sinceRef, untilRef string) (*release.TrunkData, error
 
 	log.WithFields("count", len(commits)).Debug("commits fetched for trunk")
 
+	// short-circuit: no commits in range means nothing to attribute to PRs or
+	// issues, so skip the changelog pipeline and the GitHub API fetches and
+	// return an empty trunk view.
+	if len(commits) == 0 {
+		return &release.TrunkData{Commits: []release.TrunkCommit{}}, nil
+	}
+
 	commitHashSet := strset.New()
 	for _, c := range commits {
 		commitHashSet.Add(c.Hash)

--- a/cmd/chronicle/cli/commands/create_github_worker.go
+++ b/cmd/chronicle/cli/commands/create_github_worker.go
@@ -130,12 +130,23 @@ func resolveEvidenceLeaves(evidence *event.Tree, summer *github.Summarizer, desc
 		description.CommitTotal = commitTotal
 	}
 
-	prsKept := summer.PRsKept()
-	issuesKept := summer.IssuesKept()
+	// commits is always resolved with its count: it is the signal we acted on
+	// (zero commits is what drove the short-circuit).
 	associatedCommits := summer.AssociatedCommits()
-
 	evidence.Leaf("commits").Resolve(strconv.Itoa(commitTotal),
 		droppedTrailer(commitTotal, associatedCommits))
+
+	// when there were no commits in scope the issue/PR fetches were skipped, so
+	// mark those leaves as skipped rather than resolved-with-zero — a zero count
+	// would imply we looked and found nothing.
+	if summer.DetailFetchSkipped() {
+		evidence.Leaf("issues").Skip()
+		evidence.Leaf("pull requests").Skip()
+		return
+	}
+
+	issuesKept := summer.IssuesKept()
+	prsKept := summer.PRsKept()
 	evidence.Leaf("issues").Resolve(strconv.Itoa(issueTotal),
 		droppedTrailer(issueTotal, issuesKept))
 	evidence.Leaf("pull requests").Resolve(strconv.Itoa(prTotal),

--- a/cmd/chronicle/cli/ui/__snapshots__/handler_test.snap
+++ b/cmd/chronicle/cli/ui/__snapshots__/handler_test.snap
@@ -26,3 +26,11 @@ Evidence
 └── ✔ pull requests   164   (87 kept)
 
 ---
+
+[TestTreeGroup_Snapshot_Skipped - 1]
+Evidence
+├── ✔ commits         0
+├── ⊘ issues          skipped
+└── ⊘ pull requests   skipped
+
+---

--- a/cmd/chronicle/cli/ui/handler_test.go
+++ b/cmd/chronicle/cli/ui/handler_test.go
@@ -152,6 +152,18 @@ func TestTreeGroup_Snapshot_Resolved(t *testing.T) {
 	snaps.MatchSnapshot(t, tg.View())
 }
 
+func TestTreeGroup_Snapshot_Skipped(t *testing.T) {
+	// HEAD sits on the previous release: commits resolve to zero and the issue
+	// and PR fetches are skipped entirely (no count, distinct mark).
+	tr := event.NewTree("evidence", []string{"commits", "issues", "pull requests"})
+	tr.Leaf("commits").Resolve("0", "")
+	tr.Leaf("issues").Skip()
+	tr.Leaf("pull requests").Skip()
+
+	tg := buildTreeGroup(tr)
+	snaps.MatchSnapshot(t, tg.View())
+}
+
 func buildBracketGroup(g *event.Group) tea.Model {
 	sp := newChronicleSpinner()
 	return NewBracketGroup(g, "", &sp)

--- a/cmd/chronicle/cli/ui/leaf.go
+++ b/cmd/chronicle/cli/ui/leaf.go
@@ -51,6 +51,9 @@ func (l leaf) View() string {
 			b.WriteString("   ")
 			b.WriteString(dimStyle.Render("(" + note + ")"))
 		}
+	case event.SlotSkipped:
+		// no count — the work was intentionally not performed
+		b.WriteString(dimStyle.Render("skipped"))
 	case event.SlotFailed:
 		if err := l.data.Err(); err != nil {
 			b.WriteString(dimStyle.Render(err.Error()))
@@ -73,6 +76,8 @@ func (l leaf) markView() string {
 		return okMarkStyle.Render(checkMark)
 	case event.SlotFailed:
 		return failStyle.Render(xMark)
+	case event.SlotSkipped:
+		return dimStyle.Render(skipMark)
 	case event.SlotRunning:
 		if l.sp != nil {
 			return l.sp.View()

--- a/cmd/chronicle/cli/ui/style.go
+++ b/cmd/chronicle/cli/ui/style.go
@@ -25,6 +25,7 @@ const (
 	checkMark = "✔" // U+2714 Heavy Check Mark
 	xMark     = "✘" // U+2718 Heavy Ballot X
 	dotMark   = "·"
+	skipMark  = "⊘" // U+2298 Circled Division Slash — work intentionally skipped
 	arrow     = "→"
 )
 

--- a/internal/bus/__snapshots__/summary_test.snap
+++ b/internal/bus/__snapshots__/summary_test.snap
@@ -57,3 +57,18 @@ Changes
 
 v0.18.0 → v0.18.1   (patch bump)
 ---
+
+[TestReportSummary_SkippedEvidence - 1]
+├── ✔ since   latest release → v1.45.0  9673f86  Jun 2 2026
+└── ✔ until   HEAD → v1.45.0
+
+Evidence
+├── ✔ commits         0
+├── ⊘ issues          skipped
+└── ⊘ pull requests   skipped
+
+Changes
+├── major   removed=1
+├── minor   added=3 changed=5
+└── patch   fixed=11
+---

--- a/internal/bus/summary.go
+++ b/internal/bus/summary.go
@@ -229,7 +229,12 @@ func renderEvidence() string {
 		}
 		mark := stateMark(l.State())
 		nm := padRight(name, nameWidth)
+		// a skipped leaf carries no count; show "skipped" in its place rather
+		// than a blank or a misleading zero.
 		count := padRight(l.Count(), countWidth)
+		if l.State() == event.SlotSkipped {
+			count = dimStyle.Render("skipped")
+		}
 		line := fmt.Sprintf("%s %s %s   %s", dimStyle.Render(prefix), mark, nm, count)
 		if note := l.Note(); note != "" {
 			line += "  " + dimStyle.Render("("+note+")")
@@ -459,6 +464,8 @@ func stateMark(s event.SlotState) string {
 		return okMarkStyle.Render("✔")
 	case event.SlotFailed:
 		return failMarkStyle.Render("✘")
+	case event.SlotSkipped:
+		return dimStyle.Render("⊘")
 	}
 	// pending or running (the post-teardown summary should not normally see
 	// running states, but render a dim dot for either)

--- a/internal/bus/summary_test.go
+++ b/internal/bus/summary_test.go
@@ -114,6 +114,35 @@ func TestReportSummary_NoSpeculation(t *testing.T) {
 	snaps.MatchSnapshot(t, out)
 }
 
+func TestReportSummary_SkippedEvidence(t *testing.T) {
+	// HEAD sits exactly on the previous release: zero commits in scope, so the
+	// issue and PR fetches were skipped. The evidence block should render those
+	// two leaves as "skipped" rather than a resolved zero count.
+	resetSummaryCache()
+	t.Cleanup(resetSummaryCache)
+
+	rng := PublishGroup("range", []event.GroupSlotInit{
+		{Name: "since", Label: "since", Intent: "latest release"},
+		{Name: "until", Label: "until", Intent: "HEAD"},
+	})
+	rng.Slot("since").Resolve("v1.45.0", "9673f86", "Jun 2 2026")
+	rng.Slot("until").Resolve("v1.45.0")
+
+	ev := PublishTree("evidence", []string{"commits", "issues", "pull requests"})
+	ev.Leaf("commits").Resolve("0", "")
+	ev.Leaf("issues").Skip()
+	ev.Leaf("pull requests").Skip()
+
+	out := buildSummary(SummaryOpts{
+		Description:     newDescription(),
+		PreviousVersion: "v1.45.0",
+		NextVersion:     "", // nothing changed, no speculation
+		BumpKind:        change.SemVerUnknown,
+	})
+	require.NotEmpty(t, out)
+	snaps.MatchSnapshot(t, out)
+}
+
 func TestReportSummary_NoBump(t *testing.T) {
 	resetSummaryCache()
 	t.Cleanup(resetSummaryCache)

--- a/internal/git/tag.go
+++ b/internal/git/tag.go
@@ -67,13 +67,17 @@ func CommitsBetween(repoPath string, cfg Range) ([]string, error) {
 		hash := c.Hash.String()
 
 		switch {
-		case untilHash != nil && c.Hash == *untilHash:
-			if cfg.IncludeEnd {
-				commits = append(commits, hash)
-			}
+		// check the since boundary first: it is the stop condition, so when since
+		// and until resolve to the same commit (e.g. HEAD sits exactly on the
+		// previous release tag) we still halt the walk instead of running it to
+		// the root of history.
 		case sinceHash != nil && c.Hash == *sinceHash:
 			retErr = storer.ErrStop
 			if cfg.IncludeStart {
+				commits = append(commits, hash)
+			}
+		case untilHash != nil && c.Hash == *untilHash:
+			if cfg.IncludeEnd {
 				commits = append(commits, hash)
 			}
 		default:
@@ -128,13 +132,17 @@ func CommitsBetweenWithMeta(repoPath string, cfg Range) ([]Commit, error) {
 		}
 
 		switch {
-		case untilHash != nil && c.Hash == *untilHash:
-			if cfg.IncludeEnd {
-				commits = append(commits, entry)
-			}
+		// check the since boundary first: it is the stop condition, so when since
+		// and until resolve to the same commit (e.g. HEAD sits exactly on the
+		// previous release tag) we still halt the walk instead of running it to
+		// the root of history.
 		case sinceHash != nil && c.Hash == *sinceHash:
 			retErr = storer.ErrStop
 			if cfg.IncludeStart {
+				commits = append(commits, entry)
+			}
+		case untilHash != nil && c.Hash == *untilHash:
+			if cfg.IncludeEnd {
 				commits = append(commits, entry)
 			}
 		default:

--- a/internal/git/tag_test.go
+++ b/internal/git/tag_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -120,6 +121,49 @@ func TestSearchForTag(t *testing.T) {
 			} else {
 				require.Nil(t, actual)
 				require.Error(t, err)
+			}
+		})
+	}
+}
+
+// TestCommitsBetween_sinceEqualsUntil covers the degenerate range where since
+// and until resolve to the same commit — e.g. running chronicle on the tip of
+// main when HEAD sits exactly on the previous release tag. The walk must halt
+// at the since boundary rather than running to the root of history.
+func TestCommitsBetween_sinceEqualsUntil(t *testing.T) {
+	tests := []struct {
+		name   string
+		config Range
+		count  int
+	}{
+		{
+			name: "exclusive start (default release behavior) yields nothing",
+			config: Range{
+				SinceRef:     "v0.2.0",
+				UntilRef:     "v0.2.0",
+				IncludeStart: false,
+				IncludeEnd:   true,
+			},
+			count: 0,
+		},
+		{
+			name: "inclusive start yields just the shared commit",
+			config: Range{
+				SinceRef:     "v0.2.0",
+				UntilRef:     "v0.2.0",
+				IncludeStart: true,
+				IncludeEnd:   true,
+			},
+			count: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := CommitsBetween("testdata/repos/tag-range-repo", tt.config)
+			require.NoError(t, err)
+			require.Len(t, actual, tt.count)
+			if tt.count == 1 {
+				require.Equal(t, gitTagCommit(t, "testdata/repos/tag-range-repo", "v0.2.0"), actual[0])
 			}
 		})
 	}
@@ -246,6 +290,19 @@ func TestCommitsBetweenWithMeta(t *testing.T) {
 			count: 2,
 		},
 		{
+			// since == until: HEAD sits exactly on the previous release tag. The
+			// walk must stop at the since boundary, not run to the root of history.
+			name: "since equals until (exclusive start)",
+			path: "testdata/repos/tag-range-repo",
+			config: Range{
+				SinceRef:     "v0.2.0",
+				UntilRef:     "v0.2.0",
+				IncludeStart: false,
+				IncludeEnd:   true,
+			},
+			count: 0,
+		},
+		{
 			name: "invalid since ref",
 			path: "testdata/repos/tag-range-repo",
 			config: Range{
@@ -272,7 +329,7 @@ func TestCommitsBetweenWithMeta(t *testing.T) {
 
 			// build expected commits from git directly and compare metadata fields
 			expected := gitCommitsWithMeta(t, tt.path, tt.config)
-			if diff := cmp.Diff(expected, got); diff != "" {
+			if diff := cmp.Diff(expected, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
Running chronicle on the tip of main right after a release would chew through the entire history (e.g. all 3345 commits) instead of finding zero. This fixes that and makes a no-op release actually do nothing.

- fixed the commit walk in `CommitsBetween`/`CommitsBetweenWithMeta`: when `since` and `until` resolve to the same commit (HEAD sitting on the latest release tag), the walk never hit the stop condition and ran all the way to the root. Now the since-boundary is checked first so it stops correctly and returns 0.
- short-circuit the whole analysis when there are no commits in scope — skip the issue and PR fetches entirely instead of hitting the GitHub API for nothing.
- added a new "skipped" state to the evidence rows so the TUI (and the post-teardown summary) show `⊘ issues skipped` rather than a misleading `✔ issues 0`.
