### PR TITLE
Update release pipeline to use token

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,13 +1,4 @@
 # Dependabot configuration
-#
-# Grouping behavior (see inline comments for details):
-#   - Minor + patch updates: grouped into a single PR per ecosystem
-#   - Major version bumps: individual PR per dependency
-#   - Security updates: individual PR per dependency
-#
-# Note: "patch" refers to semver version bumps (1.2.3 -> 1.2.4), not security fixes.
-# Security updates are identified separately via GitHub's Advisory Database and
-# can be any version bump (patch, minor, or major) that fixes a known CVE.
 
 version: 2
 
@@ -25,14 +16,6 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-    groups:
-      go-minor-patch:
-        applies-to: version-updates  # security updates get individual PRs
-        patterns:
-          - "*"
-        update-types:  # major omitted, gets individual PRs
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "github-actions"
     directories:
@@ -46,11 +29,3 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-    groups:
-      actions-minor-patch:
-        applies-to: version-updates  # security updates get individual PRs
-        patterns:
-          - "*"
-        update-types:  # major omitted, gets individual PRs
-          - "minor"
-          - "patch"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,11 @@ on:
       version:
         description: tag the latest commit on main with the given version (prefixed with v)
         required: true
+      skip-checks:
+        description: skip the check-gate job (release even if checks have not passed)
+        type: boolean
+        default: false
+        required: false
 
 jobs:
   version-available:
@@ -22,6 +27,7 @@ jobs:
       version: ${{ github.event.inputs.version }}
 
   check-gate:
+    if: ${{ !inputs.skip-checks }}
     permissions:
       checks: read # required for getting the status of specific check names
     uses: anchore/workflows/.github/workflows/check-gate.yaml@b0c30a80409130d329aaa356fd64a34d8c0b3375 # v0.7.2
@@ -30,6 +36,14 @@ jobs:
 
   release:
     needs: [check-gate, version-available]
+    # run even when check-gate is skipped, but never when version-available
+    # failed/was skipped, nor when check-gate failed or was cancelled. note:
+    # always() disables the implicit success() gate on ALL needs, so the
+    # version-available requirement must be re-asserted explicitly here.
+    if: >-
+      ${{ always()
+          && needs.version-available.result == 'success'
+          && !contains(fromJSON('["failure", "cancelled"]'), needs.check-gate.result) }}
     environment: release
     runs-on: ubuntu-24.04
     permissions:
@@ -48,8 +62,8 @@ jobs:
       - name: Build & publish release artifacts
         run: make ci-release
         env:
-          # for pushing tags (requires write access to content, but not packages)
-          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+          # for pushing tags (does not inherit workflow permissions)
+          TAG_TOKEN: ${{ secrets.TAG_TOKEN }}
           RELEASE_VERSION: ${{ github.event.inputs.version }}
           # for mac signing and notarization...
           QUILL_SIGN_P12: ${{ secrets.ANCHORE_APPLE_DEVELOPER_ID_CERT_CHAIN }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,1 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        # anchore/workflows is an internal repository; using @main is acceptable
-        anchore/*: any
+rules: {}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ go.work.sum
 .tool-versions
 .mise.toml
 .env
+.make/.make
 
 # tool and bin directories
 .tmp/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -87,8 +87,15 @@ issues:
 
 formatters:
   enable:
+    - gci
     - gofmt
-    - goimports
+  settings:
+    gci:
+      # See https://golangci-lint.run/docs/formatters/configuration/#gci
+      sections:
+        - standard # Standard section: captures all standard packages.
+        - default  # Default section: contains all imports that could not be matched to another section type.
+        - prefix(github.com/anchore)
   exclusions:
     generated: lax
     paths:

--- a/.make/go.mod
+++ b/.make/go.mod
@@ -2,11 +2,11 @@ module github.com/anchore/chronicle/.make
 
 go 1.25.0
 
-require github.com/anchore/go-make v0.3.2
+require github.com/anchore/go-make v0.6.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
-	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/mod v0.36.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 )

--- a/.make/go.sum
+++ b/.make/go.sum
@@ -1,10 +1,10 @@
-github.com/anchore/go-make v0.3.2 h1:Cu5/eqLXwQozOxPsECqm+S5xJUMlumbfzOR8ysP92Gw=
-github.com/anchore/go-make v0.3.2/go.mod h1:Nc/tkwQHW1d1Vi8+0rtS/vSrH6pxieaUQXLdrctn+8g=
+github.com/anchore/go-make v0.6.0 h1:a2X8gwKBxfpy82sZ7NuxXqIM1itbu1KG1584bVmSj68=
+github.com/anchore/go-make v0.6.0/go.mod h1:lpHJuDoTeVkGt87Gd+9h9v7+Wag+vFAgOSLu7r2iIFo=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
 github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
-golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
-golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
This replaces the deploy key approach with a token. Additionally changes surrounding material like dependabot configuration, linter configurtion, and zizmore exceptions.