### PR TITLE
Add auto-detection of dependency ecosystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ bin/
 /bin
 /.bin
 /build
+
+# compiled go-make binary (built on demand by `go run -C .make .`)
+/.make/.make
 .mise.toml
 .tool/
 /bin

--- a/.make/main.go
+++ b/.make/main.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+
 	. "github.com/anchore/go-make"
+	"github.com/anchore/go-make/lang"
+	"github.com/anchore/go-make/run"
 	"github.com/anchore/go-make/tasks/golint"
 	"github.com/anchore/go-make/tasks/goreleaser"
 	"github.com/anchore/go-make/tasks/gotest"
@@ -13,5 +18,31 @@ func main() {
 		goreleaser.Tasks(),
 		gotest.Tasks(),
 		gotest.FixtureTasks().RunOn("unit"),
+		verifyGeneratedTask(),
 	)
+}
+
+// generatedFiles are the checked-in artifacts produced by `go generate`. They are
+// idempotent, so a clean checkout that re-runs generation must see no changes.
+var generatedFiles = []string{
+	"cmd/chronicle/cli/options/ecosystems.gen.yaml",
+}
+
+// verifyGeneratedTask re-runs code generation and fails if a committed artifact
+// drifted — guarding the syft-derived ecosystem detection table against a stale
+// check-in (e.g. a syft bump landed without re-running `go generate`). It hooks
+// into static-analysis so CI enforces it on every PR.
+func verifyGeneratedTask() Task {
+	return Task{
+		Name:        "verify-generated",
+		Description: "ensure committed generated files match `go generate` output",
+		RunsOn:      lang.List("static-analysis"),
+		Run: func() {
+			Run("go generate ./cmd/chronicle/cli/options/...")
+			args := strings.Join(generatedFiles, " ")
+			if dirty := strings.TrimSpace(Run("git status --porcelain -- "+args, run.NoFail())); dirty != "" {
+				lang.Throw(fmt.Errorf("generated files are out of date; run `go generate ./...` and commit:\n%s", dirty))
+			}
+		},
+	}
 }

--- a/README.md
+++ b/README.md
@@ -295,6 +295,18 @@ chronicle --dependencies language
 
 Scoping to an ecosystem keeps the section focused: `--dependencies go` reports only Go modules, not the GitHub Actions, OS packages, or other manifests syft can also find in the tree.
 
+Use `auto` to detect ecosystems from manifests at the repository root and enable only those — handy for a single config that works across repos. The markers come straight from syft's own cataloger metadata, so detection matches what syft would actually catalog: it keys off the manifests/lockfiles syft's declared-language catalogers read (e.g. `go.mod` → `go`, `package-lock.json`/`yarn.lock` → `javascript`, `Cargo.lock` → `rust`), not every file an ecosystem might have. Detection is root-only; if nothing is recognized the section is simply omitted. `auto` may be combined with explicit ecosystems (`--dependencies auto,go`).
+
+```bash
+chronicle --dependencies auto
+```
+
+To disable the feature — for example to override an `auto` set in a committed config for one run — pass `none`, which wins over every other value:
+
+```bash
+chronicle --dependencies none
+```
+
 To annotate each change with the CVEs/GHSAs it remediated or introduced, add `--vulnerabilities` (this downloads/loads the grype vulnerability DB — see below):
 
 ```bash
@@ -342,7 +354,9 @@ All dependency options live under the `dependencies:` key. Default values are sh
 dependencies:
   # ecosystems to scan (syft cataloger selection, e.g. language, go, python).
   # the feature is enabled when this is non-empty. "language" selects all
-  # language ecosystems. same as --dependencies (repeatable / comma-separated).
+  # language ecosystems. "auto" detects ecosystems from root manifests; "none"
+  # disables the feature and wins over all other values. same as --dependencies
+  # (repeatable / comma-separated).
   ecosystems: []
 
   # paths to exclude from the scan (e.g. vendored or test trees), as syft

--- a/chronicle/release/output/encoders/markdown/__snapshots__/encoder_test.snap
+++ b/chronicle/release/output/encoders/markdown/__snapshots__/encoder_test.snap
@@ -220,7 +220,7 @@
 
 **Toolchains (1)**
 
-- Go minimum version: 1.21 → 1.23
+- Go minimum version: `1.21` → `1.23`
 
 **[(Full Changelog)](https://github.com/anchore/syft/compare/v0.19.0...v0.19.1)**
 
@@ -233,7 +233,7 @@
 
 **Toolchains (1)**
 
-- Go minimum version: 1.23 → 1.21 (downgrade)
+- Go minimum version: `1.23` → `1.21` (downgrade)
 
 **[(Full Changelog)](https://github.com/anchore/syft/compare/v0.19.0...v0.19.1)**
 
@@ -252,7 +252,7 @@
 
 **Toolchains (1)**
 
-- Go minimum version: 1.21 → 1.23
+- Go minimum version: `1.21` → `1.23`
 
 <details>
 <summary>Updated (1 package)</summary>

--- a/chronicle/release/output/encoders/markdown/encoder.go
+++ b/chronicle/release/output/encoders/markdown/encoder.go
@@ -181,7 +181,7 @@ func toolchainRollup(tc *release.ToolchainData) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "**Toolchains (%d)**\n\n", len(lines))
 	for _, l := range lines {
-		fmt.Fprintf(&sb, "- %s minimum version: %s → %s", l.Label, l.From, l.To)
+		fmt.Fprintf(&sb, "- %s minimum version: `%s` → `%s`", l.Label, l.From, l.To)
 		if l.Direction == release.ToolchainDowngrade {
 			sb.WriteString(" (downgrade)")
 		}

--- a/chronicle/release/output/encoders/slack/__snapshots__/encoder_test.snap
+++ b/chronicle/release/output/encoders/slack/__snapshots__/encoder_test.snap
@@ -91,7 +91,7 @@
 *Dependencies*
 
 *Toolchains (1)*
-• Go minimum version: 1.21 → 1.23
+• Go minimum version: `1.21` → `1.23`
 
 *<https://github.com/anchore/syft/compare/v0.19.0...v0.19.1|Full Changelog>*
 
@@ -103,7 +103,7 @@
 *Dependencies*
 
 *Toolchains (1)*
-• Go minimum version: 1.23 → 1.21 (downgrade)
+• Go minimum version: `1.23` → `1.21` (downgrade)
 
 *<https://github.com/anchore/syft/compare/v0.19.0...v0.19.1|Full Changelog>*
 

--- a/chronicle/release/output/encoders/slack/encoder.go
+++ b/chronicle/release/output/encoders/slack/encoder.go
@@ -257,7 +257,7 @@ func toolchainRollup(tc *release.ToolchainData) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "*Toolchains (%d)*\n", len(lines))
 	for _, l := range lines {
-		fmt.Fprintf(&sb, "• %s minimum version: %s → %s", escapeMrkdwn(l.Label), escapeMrkdwn(l.From), escapeMrkdwn(l.To))
+		fmt.Fprintf(&sb, "• %s minimum version: `%s` → `%s`", escapeMrkdwn(l.Label), escapeMrkdwn(l.From), escapeMrkdwn(l.To))
 		if l.Direction == release.ToolchainDowngrade {
 			sb.WriteString(" (downgrade)")
 		}

--- a/cmd/chronicle/cli/commands/create.go
+++ b/cmd/chronicle/cli/commands/create.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -80,6 +81,20 @@ func runCreate(ctx context.Context, appConfig *createConfig) error {
 	// until after the worker succeeds so failures don't leak temp files.
 	if err := appConfig.Check(); err != nil {
 		return err
+	}
+
+	// resolve the auto/none ecosystem sentinels against the project root before
+	// validation so Enabled() and the worker only ever see concrete selectors.
+	resolved, hadAuto, err := appConfig.Dependencies.ResolveEcosystems(appConfig.RepoPath)
+	if err != nil {
+		return err
+	}
+	if hadAuto {
+		if len(resolved) == 0 {
+			log.Infof("no dependency ecosystems detected at %q", appConfig.RepoPath)
+		} else {
+			log.Infof("detected dependency ecosystems: %s", strings.Join(resolved, ", "))
+		}
 	}
 
 	// vulnerability annotation operates on the dependency diff, so it has

--- a/cmd/chronicle/cli/commands/create_config.go
+++ b/cmd/chronicle/cli/commands/create_config.go
@@ -58,7 +58,7 @@ func (c *createConfig) AddFlags(flags clio.FlagSet) {
 	flags.StringArrayVarP(
 		&c.Dependencies.Ecosystems,
 		"dependencies", "",
-		"scan and diff source dependencies for the given ecosystem(s) (e.g. language, go, python); repeatable or comma-separated. Enables the dependencies section.",
+		"scan and diff source dependencies for the given ecosystem(s) (e.g. language, go, python); use 'auto' to detect ecosystems from root manifests, or 'none' to disable; repeatable or comma-separated. Enables the dependencies section.",
 	)
 
 	flags.BoolVarP(

--- a/cmd/chronicle/cli/options/dependencies.go
+++ b/cmd/chronicle/cli/options/dependencies.go
@@ -54,7 +54,7 @@ func (c Dependencies) Enabled() bool {
 }
 
 func (c *Dependencies) DescribeFields(descriptions clio.FieldDescriptionSet) {
-	descriptions.Add(&c.Ecosystems, "ecosystems to scan (syft cataloger selection, e.g. language, go, python); enables the feature when set")
+	descriptions.Add(&c.Ecosystems, "ecosystems to scan (syft cataloger selection, e.g. language, go, python); 'auto' detects ecosystems from root manifests, 'none' disables (wins over all); enables the feature when set")
 	descriptions.Add(&c.Exclude, "paths to exclude from dependency scanning (syft exclude patterns; each must start with ./, */, or **/, e.g. ./vendor, **/testdata)")
 	descriptions.Add(&c.AnnotateVulnerabilities, "annotate dependency changes with known vulnerability information")
 	descriptions.Add(&c.OnlyVulnerable, "only show dependency changes that remediated or introduced a vulnerability (requires annotate-vulnerabilities)")

--- a/cmd/chronicle/cli/options/dependencies_detect.go
+++ b/cmd/chronicle/cli/options/dependencies_detect.go
@@ -1,0 +1,168 @@
+package options
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"gopkg.in/yaml.v3"
+
+	"github.com/anchore/chronicle/chronicle/dependency"
+)
+
+// autoEcosystem expands to the ecosystems detected at the repo root; noneEcosystem
+// disables the feature entirely and wins over every other value (including auto).
+const (
+	autoEcosystem = "auto"
+	noneEcosystem = "none"
+)
+
+//go:generate go run ./internal/genecosystems
+
+// ecosystemCapabilities is the chronicle-owned, version-pinned copy of syft's
+// declared-language cataloger globs (per ecosystem), baked from the syft module
+// cache by `go generate` (see internal/genecosystems). syft offers no importable
+// API for this mapping, so we carry our own copy and re-derive it on each syft
+// bump rather than hand-maintaining glob patterns. Entries are scoped to
+// chronicle's dependency.Ecosystem registry and listed in canonical order.
+//
+//go:embed ecosystems.gen.yaml
+var ecosystemCapabilities []byte
+
+// ecosystemGlobs pairs a chronicle ecosystem identifier with the root-manifest
+// globs that imply it.
+type ecosystemGlobs struct {
+	Ecosystem string   `yaml:"ecosystem"`
+	Globs     []string `yaml:"globs"`
+}
+
+var (
+	loadEcosystemsOnce sync.Once
+	loadedEcosystems   []ecosystemGlobs
+	loadEcosystemsErr  error
+)
+
+// detectionTable parses the embedded capabilities once and caches the result.
+func detectionTable() ([]ecosystemGlobs, error) {
+	loadEcosystemsOnce.Do(func() {
+		var doc struct {
+			Ecosystems []ecosystemGlobs `yaml:"ecosystems"`
+		}
+		if err := yaml.Unmarshal(ecosystemCapabilities, &doc); err != nil {
+			loadEcosystemsErr = fmt.Errorf("unable to parse embedded ecosystem capabilities: %w", err)
+			return
+		}
+		loadedEcosystems = doc.Ecosystems
+	})
+	return loadedEcosystems, loadEcosystemsErr
+}
+
+// detectEcosystems inspects the top level of root for the manifest globs syft's
+// declared-language catalogers match, and returns the canonical syft selectors
+// (dependency.Ecosystem.Selector) for the ecosystems present, in canonical order.
+// Detection is non-recursive: it decides which ecosystems to enable, and syft
+// handles the deep scan from there. Because the globs come from syft, detection
+// tracks what syft would actually catalog — e.g. JavaScript keys off lockfiles,
+// not package.json. Returns nil when nothing matches.
+func detectEcosystems(root string) ([]string, error) {
+	table, err := detectionTable()
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read project root %q for ecosystem detection: %w", root, err)
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+
+	var out []string
+	for _, eco := range table {
+		// route through the registry so the emitted selector is canonical and
+		// any ecosystem the registry no longer knows is skipped rather than
+		// passed to syft as an unknown selector.
+		known, ok := dependency.ParseEcosystem(eco.Ecosystem)
+		if !ok {
+			continue
+		}
+		if anyGlobMatches(eco.Globs, names) {
+			out = append(out, known.Selector())
+		}
+	}
+	return out, nil
+}
+
+// anyGlobMatches reports whether any glob matches any of the root-level filenames.
+// syft globs are "**/"-prefixed (recursive); doublestar matches those against a
+// bare root filename (e.g. "**/go.mod" matches "go.mod"), so root-only detection
+// works without walking the tree.
+func anyGlobMatches(globs, names []string) bool {
+	for _, g := range globs {
+		for _, n := range names {
+			if ok, _ := doublestar.Match(g, n); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ResolveEcosystems expands the configured ecosystem sentinels against the project
+// root and rewrites Ecosystems with concrete syft selectors. The "none" sentinel wins
+// over everything (clears the list, disabling the feature); otherwise "auto" is
+// replaced by the detected selectors and merged with any explicit ones (deduped,
+// detected first in canonical order, explicit order preserved). hadAuto reports whether
+// an auto token was present so the caller can log the detection outcome.
+func (c *Dependencies) ResolveEcosystems(root string) (resolved []string, hadAuto bool, err error) {
+	cleaned := c.CleanedEcosystems()
+
+	for _, e := range cleaned {
+		if strings.EqualFold(e, noneEcosystem) {
+			c.Ecosystems = nil
+			return nil, false, nil
+		}
+	}
+
+	var out []string
+	seen := make(map[string]struct{})
+	add := func(selector string) {
+		if _, ok := seen[selector]; ok {
+			return
+		}
+		seen[selector] = struct{}{}
+		out = append(out, selector)
+	}
+
+	for _, e := range cleaned {
+		if !strings.EqualFold(e, autoEcosystem) {
+			continue
+		}
+		hadAuto = true
+		detected, derr := detectEcosystems(root)
+		if derr != nil {
+			return nil, hadAuto, derr
+		}
+		for _, d := range detected {
+			add(d)
+		}
+	}
+
+	// keep explicit selectors after the detected set, preserving their order.
+	for _, e := range cleaned {
+		if strings.EqualFold(e, autoEcosystem) {
+			continue
+		}
+		add(e)
+	}
+
+	c.Ecosystems = out
+	return out, hadAuto, nil
+}

--- a/cmd/chronicle/cli/options/dependencies_detect_test.go
+++ b/cmd/chronicle/cli/options/dependencies_detect_test.go
@@ -1,0 +1,222 @@
+package options
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/chronicle/chronicle/dependency"
+)
+
+// TestDetectionTableMatchesRegistry guards against drift between the generated
+// detection table and the dependency.Ecosystem registry: every generated entry
+// must resolve to a known ecosystem (so detection emits a canonical selector and
+// nothing is silently dropped). If a syft bump introduces a new declared-language
+// ecosystem, either add it to the registry or accept that genecosystems skips it.
+func TestDetectionTableMatchesRegistry(t *testing.T) {
+	table, err := detectionTable()
+	require.NoError(t, err)
+	require.NotEmpty(t, table)
+
+	for _, e := range table {
+		_, ok := dependency.ParseEcosystem(e.Ecosystem)
+		require.Truef(t, ok, "generated ecosystem %q is not in the dependency.Ecosystem registry", e.Ecosystem)
+		require.NotEmptyf(t, e.Globs, "generated ecosystem %q has no globs", e.Ecosystem)
+	}
+}
+
+func TestDetectEcosystems(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   []string
+		want    []string
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name:  "go via go.mod",
+			files: []string{"go.mod", "go.sum", "main.go"},
+			want:  []string{"go"},
+		},
+		{
+			// syft's declared catalogers key off lockfiles/manifests, so detection
+			// matches what syft would actually catalog: a Cargo.lock (not Cargo.toml),
+			// a package-lock.json (not package.json), etc. Results come back in
+			// canonical registry order (go, javascript, python, ..., rust).
+			name:  "multiple ecosystems in canonical order",
+			files: []string{"Cargo.lock", "go.mod", "package-lock.json", "requirements.txt"},
+			want:  []string{"go", "javascript", "python", "rust"},
+		},
+		{
+			name:  "ruby matched by gemspec suffix glob",
+			files: []string{"foo.gemspec"},
+			want:  []string{"ruby"},
+		},
+		{
+			name:  "python matched by requirements glob",
+			files: []string{"dev-requirements.txt"},
+			want:  []string{"python"},
+		},
+		{
+			// package.json alone is not a declared-cataloger marker (syft keys
+			// JavaScript off lockfiles), so it must not enable javascript.
+			name:  "package.json alone does not detect javascript",
+			files: []string{"package.json"},
+			want:  nil,
+		},
+		{
+			name:  "no recognized markers",
+			files: []string{"README.md", "LICENSE"},
+			want:  nil,
+		},
+		{
+			name:  "empty dir",
+			files: nil,
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
+			}
+
+			root := t.TempDir()
+			for _, f := range tt.files {
+				require.NoError(t, os.WriteFile(filepath.Join(root, f), []byte(""), 0600))
+			}
+
+			got, err := detectEcosystems(root)
+			tt.wantErr(t, err)
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("unexpected ecosystems (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDetectEcosystems_unreadableRoot(t *testing.T) {
+	_, err := detectEcosystems(filepath.Join(t.TempDir(), "does-not-exist"))
+	require.Error(t, err)
+}
+
+func TestDependencies_ResolveEcosystems(t *testing.T) {
+	tests := []struct {
+		name        string
+		ecosystems  []string
+		files       []string // markers written to the temp root
+		want        []string
+		wantHadAuto bool
+		wantEnabled bool
+		wantErr     require.ErrorAssertionFunc
+	}{
+		{
+			name:        "auto expands to detected",
+			ecosystems:  []string{"auto"},
+			files:       []string{"go.mod"},
+			want:        []string{"go"},
+			wantHadAuto: true,
+			wantEnabled: true,
+		},
+		{
+			name:        "auto detects nothing leaves feature off",
+			ecosystems:  []string{"auto"},
+			files:       []string{"README.md"},
+			want:        nil,
+			wantHadAuto: true,
+			wantEnabled: false,
+		},
+		{
+			name:        "auto deduped against explicit",
+			ecosystems:  []string{"auto", "go"},
+			files:       []string{"go.mod"},
+			want:        []string{"go"},
+			wantHadAuto: true,
+			wantEnabled: true,
+		},
+		{
+			name:        "auto detected first then explicit preserved",
+			ecosystems:  []string{"auto", "ruby"},
+			files:       []string{"go.mod"},
+			want:        []string{"go", "ruby"},
+			wantHadAuto: true,
+			wantEnabled: true,
+		},
+		{
+			name:        "auto is case-insensitive",
+			ecosystems:  []string{"AUTO"},
+			files:       []string{"go.mod"},
+			want:        []string{"go"},
+			wantHadAuto: true,
+			wantEnabled: true,
+		},
+		{
+			name:        "no sentinel passthrough",
+			ecosystems:  []string{"go", "python"},
+			want:        []string{"go", "python"},
+			wantHadAuto: false,
+			wantEnabled: true,
+		},
+		{
+			name:        "none disables",
+			ecosystems:  []string{"none"},
+			want:        nil,
+			wantHadAuto: false,
+			wantEnabled: false,
+		},
+		{
+			name:        "none wins over auto",
+			ecosystems:  []string{"auto", "none"},
+			files:       []string{"go.mod"},
+			want:        nil,
+			wantHadAuto: false,
+			wantEnabled: false,
+		},
+		{
+			name:        "none wins over explicit",
+			ecosystems:  []string{"go", "none"},
+			want:        nil,
+			wantHadAuto: false,
+			wantEnabled: false,
+		},
+		{
+			name:        "none is case-insensitive",
+			ecosystems:  []string{"NONE", "go"},
+			want:        nil,
+			wantHadAuto: false,
+			wantEnabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
+			}
+
+			root := t.TempDir()
+			for _, f := range tt.files {
+				require.NoError(t, os.WriteFile(filepath.Join(root, f), []byte(""), 0600))
+			}
+
+			c := Dependencies{Ecosystems: tt.ecosystems}
+			got, hadAuto, err := c.ResolveEcosystems(root)
+			tt.wantErr(t, err)
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("unexpected resolved ecosystems (-want +got):\n%s", diff)
+			}
+			require.Equal(t, tt.wantHadAuto, hadAuto)
+			require.Equal(t, tt.wantEnabled, c.Enabled())
+		})
+	}
+}

--- a/cmd/chronicle/cli/options/ecosystems.gen.yaml
+++ b/cmd/chronicle/cli/options/ecosystems.gen.yaml
@@ -1,0 +1,61 @@
+# Code generated from github.com/anchore/syft v1.45.1 by genecosystems; DO NOT EDIT.
+# Regenerate with `go generate ./...` after bumping syft.
+ecosystems:
+    - ecosystem: go
+      globs:
+        - '**/go.mod'
+    - ecosystem: javascript
+      globs:
+        - '**/package-lock.json'
+        - '**/pnpm-lock.yaml'
+        - '**/yarn.lock'
+    - ecosystem: python
+      globs:
+        - '**/*requirements*.txt'
+        - '**/Pipfile.lock'
+        - '**/pdm.lock'
+        - '**/poetry.lock'
+        - '**/setup.py'
+        - '**/uv.lock'
+    - ecosystem: java
+      globs:
+        - '**/gradle.lockfile*'
+    - ecosystem: ruby
+      globs:
+        - '**/*.gemspec'
+        - '**/Gemfile.lock'
+        - '**/Gemfile.next.lock'
+    - ecosystem: rust
+      globs:
+        - '**/Cargo.lock'
+    - ecosystem: php
+      globs:
+        - '**/composer.lock'
+        - '**/php/.registry/**/*.reg'
+    - ecosystem: dotnet
+      globs:
+        - '**/packages.lock.json'
+    - ecosystem: cpp
+      globs:
+        - '**/conan.lock'
+        - '**/conanfile.txt'
+    - ecosystem: swift
+      globs:
+        - '**/.package.resolved'
+        - '**/Package.resolved'
+        - '**/Podfile.lock'
+    - ecosystem: dart
+      globs:
+        - '**/pubspec.lock'
+        - '**/pubspec.yaml'
+        - '**/pubspec.yml'
+    - ecosystem: haskell
+      globs:
+        - '**/cabal.project.freeze'
+        - '**/stack.yaml'
+        - '**/stack.yaml.lock'
+    - ecosystem: elixir
+      globs:
+        - '**/*.app'
+        - '**/mix.lock'
+        - '**/rebar.lock'

--- a/cmd/chronicle/cli/options/internal/genecosystems/main.go
+++ b/cmd/chronicle/cli/options/internal/genecosystems/main.go
@@ -1,0 +1,219 @@
+// Command genecosystems regenerates ecosystems.gen.yaml from the pinned syft
+// module's cataloger capabilities. Run it via `go generate ./...`.
+//
+// syft exposes no importable API for the ecosystem→glob mapping (the data lives
+// in an internal package behind an unexported embed.FS), so we read the public
+// per-ecosystem capabilities.yaml files out of the module cache at generate time
+// and bake a chronicle-owned, version-pinned copy. Re-run after bumping syft;
+// CI compares the result against the committed file to catch drift.
+//
+// Output is scoped to ecosystems chronicle's registry (dependency.Ecosystem)
+// knows, so auto-detection speaks the same canonical vocabulary as the rest of
+// the codebase. syft ecosystems with no registry entry are skipped and logged.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/anchore/chronicle/chronicle/dependency"
+)
+
+const outputFile = "ecosystems.gen.yaml"
+
+// auto targets declared language dependencies: the "declared" tag scopes to
+// source manifests/lockfiles (excluding installed/image package catalogers) and
+// "language" excludes OS packages (deb/rpm), binaries, and IaC/CI ecosystems
+// (terraform, github-actions) that aren't source library dependencies.
+var requiredSelectors = []string{"declared", "language"}
+
+// capDoc mirrors the parts of syft's capabilities.yaml schema we consume.
+type capDoc struct {
+	Catalogers []struct {
+		Ecosystem string   `yaml:"ecosystem"`
+		Selectors []string `yaml:"selectors"`
+		Parsers   []struct {
+			Detector struct {
+				Method   string   `yaml:"method"`
+				Criteria []string `yaml:"criteria"`
+			} `yaml:"detector"`
+		} `yaml:"parsers"`
+	} `yaml:"catalogers"`
+}
+
+type ecosystemEntry struct {
+	Ecosystem string   `yaml:"ecosystem"`
+	Globs     []string `yaml:"globs"`
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "genecosystems:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	dir, version, err := syftModule()
+	if err != nil {
+		return err
+	}
+
+	files, err := filepath.Glob(filepath.Join(dir, "syft", "pkg", "cataloger", "*", "capabilities.yaml"))
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("no capabilities.yaml files found under %q", dir)
+	}
+
+	globsByEco, skipped, err := collectGlobs(files)
+	if err != nil {
+		return err
+	}
+
+	entries := orderedEntries(globsByEco)
+	if err := writeOutput(entries, version); err != nil {
+		return err
+	}
+
+	fmt.Printf("wrote %d ecosystems to %s (from syft %s)\n", len(entries), outputFile, version)
+	if len(skipped) > 0 {
+		fmt.Printf("skipped %d syft ecosystem(s) with no chronicle registry entry: %s\n",
+			len(skipped), strings.Join(sortedKeys(skipped), ", "))
+	}
+	return nil
+}
+
+// collectGlobs parses each capabilities file and unions the declared-language glob
+// criteria per chronicle ecosystem. It also returns the syft ecosystems skipped
+// because chronicle's registry doesn't know them.
+func collectGlobs(files []string) (globsByEco map[dependency.Ecosystem]map[string]struct{}, skipped map[string]struct{}, err error) {
+	globsByEco = map[dependency.Ecosystem]map[string]struct{}{}
+	skipped = map[string]struct{}{}
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			return nil, nil, err
+		}
+		var doc capDoc
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return nil, nil, fmt.Errorf("parse %s: %w", f, err)
+		}
+		collectFromDoc(doc, globsByEco, skipped)
+	}
+	return globsByEco, skipped, nil
+}
+
+// collectFromDoc folds one capabilities document's declared-language catalogers into
+// the running glob/skip maps.
+func collectFromDoc(doc capDoc, globsByEco map[dependency.Ecosystem]map[string]struct{}, skipped map[string]struct{}) {
+	for _, c := range doc.Catalogers {
+		if !hasAll(toSet(c.Selectors), requiredSelectors) {
+			continue
+		}
+		globs := globCriteria(c.Parsers)
+		if len(globs) == 0 {
+			continue
+		}
+		// map the syft ecosystem onto chronicle's canonical registry so
+		// auto-detection only emits ecosystems the rest of the code knows.
+		eco, ok := dependency.ParseEcosystem(c.Ecosystem)
+		if !ok {
+			skipped[c.Ecosystem] = struct{}{}
+			continue
+		}
+		if globsByEco[eco] == nil {
+			globsByEco[eco] = map[string]struct{}{}
+		}
+		for _, g := range globs {
+			globsByEco[eco][g] = struct{}{}
+		}
+	}
+}
+
+// orderedEntries emits one entry per ecosystem in canonical registry order, so the
+// detection output order has a single source of truth.
+func orderedEntries(globsByEco map[dependency.Ecosystem]map[string]struct{}) []ecosystemEntry {
+	var entries []ecosystemEntry
+	for _, eco := range dependency.Ecosystems() {
+		if globs, ok := globsByEco[eco]; ok {
+			entries = append(entries, ecosystemEntry{Ecosystem: eco.String(), Globs: sortedKeys(globs)})
+		}
+	}
+	return entries
+}
+
+// writeOutput marshals the entries with the generated-file header to outputFile.
+func writeOutput(entries []ecosystemEntry, version string) error {
+	body, err := yaml.Marshal(struct {
+		Ecosystems []ecosystemEntry `yaml:"ecosystems"`
+	}{entries})
+	if err != nil {
+		return err
+	}
+	header := fmt.Sprintf("# Code generated from github.com/anchore/syft %s by genecosystems; DO NOT EDIT.\n"+
+		"# Regenerate with `go generate ./...` after bumping syft.\n", version)
+	return os.WriteFile(outputFile, append([]byte(header), body...), 0600)
+}
+
+// syftModule returns the module cache directory and version of the pinned syft
+// dependency via `go list`, avoiding any assumptions about GOMODCACHE layout.
+func syftModule() (dir, version string, err error) {
+	out, err := exec.Command("go", "list", "-m", "-f", "{{.Dir}}\t{{.Version}}", "github.com/anchore/syft").Output()
+	if err != nil {
+		return "", "", fmt.Errorf("locating syft module: %w", err)
+	}
+	parts := strings.SplitN(strings.TrimSpace(string(out)), "\t", 2)
+	if len(parts) != 2 || parts[0] == "" {
+		return "", "", fmt.Errorf("unexpected `go list` output: %q", string(out))
+	}
+	return parts[0], parts[1], nil
+}
+
+func globCriteria(parsers []struct {
+	Detector struct {
+		Method   string   `yaml:"method"`
+		Criteria []string `yaml:"criteria"`
+	} `yaml:"detector"`
+}) []string {
+	var out []string
+	for _, p := range parsers {
+		if p.Detector.Method == "glob" {
+			out = append(out, p.Detector.Criteria...)
+		}
+	}
+	return out
+}
+
+func toSet(vals []string) map[string]struct{} {
+	s := make(map[string]struct{}, len(vals))
+	for _, v := range vals {
+		s[v] = struct{}{}
+	}
+	return s
+}
+
+func hasAll(set map[string]struct{}, keys []string) bool {
+	for _, k := range keys {
+		if _, ok := set[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/anchore/go-logger v0.1.0
 	github.com/anchore/grype v0.114.0
 	github.com/anchore/syft v1.45.1
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
@@ -30,6 +31,7 @@ require (
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/term v0.44.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -103,7 +105,6 @@ require (
 	github.com/bitnami/go-version v0.0.0-20250505154626-452e8c5ee607 // indirect
 	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb // indirect
 	github.com/bmatcuk/doublestar/v2 v2.0.4 // indirect
-	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/bodgit/plumbing v1.3.0 // indirect
 	github.com/bodgit/sevenzip v1.6.1 // indirect
 	github.com/bodgit/windows v1.0.1 // indirect
@@ -328,7 +329,6 @@ require (
 	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/gorm v1.31.1 // indirect
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect


### PR DESCRIPTION
This builds on #498 and #497 allowing for `--dependencies` to take an `auto` value and figure out which ecosystems should be selected for syft scans and toolchain detections.