### PR TITLE
Ignore dependabot authors when determining dependencies with Syft

### DIFF
--- a/chronicle/dependency/annotate.go
+++ b/chronicle/dependency/annotate.go
@@ -20,8 +20,8 @@ type PackageVulns struct {
 // annotate; a nil *VulnDelta on a PackageChange means "not annotated", distinct
 // from an empty delta meaning "annotated, no vulnerability impact".
 type VulnDelta struct {
-	Remediated []Vulnerability // present at `since` for this pkg, gone at `until`
-	Introduced []Vulnerability // present at `until`, absent at `since`
+	Remediated []Vulnerability `json:",omitempty"` // present at `since` for this pkg, gone at `until`
+	Introduced []Vulnerability `json:",omitempty"` // present at `until`, absent at `since`
 }
 
 // HasImpact reports whether the change remediated or introduced any

--- a/chronicle/dependency/diff.go
+++ b/chronicle/dependency/diff.go
@@ -53,16 +53,16 @@ type VersionComparer interface {
 // Display preferences live separately (render.Config), not here.
 type Diff struct {
 	Changes         []PackageChange
-	Totals          ChangeTotals
-	RemediatedCount int // unique vuln IDs across all changes' Remediated
-	IntroducedCount int // unique vuln IDs across all changes' Introduced
+	Totals          ChangeTotals `json:"-"`
+	RemediatedCount int          `json:"-"` // unique vuln IDs across all changes' Remediated
+	IntroducedCount int          `json:"-"` // unique vuln IDs across all changes' Introduced
 	// RemainingCount is the unique vuln IDs present at BOTH since and until —
 	// carried over, neither remediated (gone at until) nor introduced (new at
 	// until) — across every package in the latest scan, not just the changed
 	// ones. Unlike the two counts above it is not derivable from Changes (it
 	// spans unchanged packages too), so annotate sets it from the scans rather
 	// than NewDiff deriving it. Zero on an unannotated diff.
-	RemainingCount int
+	RemainingCount int `json:"-"`
 
 	// Since and Until are the scans that were compared, retained so callers
 	// can derive per-ref scan figures (package and vulnerability counts, match
@@ -95,10 +95,10 @@ type ChangeTotals struct {
 type PackageChange struct {
 	Name        string
 	Type        string // syft package type; render maps it to an ecosystem label
-	FromVersion string // "" for Added
-	ToVersion   string // "" for Removed
+	FromVersion string `json:",omitempty"` // "" for Added
+	ToVersion   string `json:",omitempty"` // "" for Removed
 	Kind        ChangeKind
-	Vuln        *VulnDelta // nil unless annotated
+	Vuln        *VulnDelta `json:",omitempty"` // nil unless annotated
 }
 
 // ComputeDiff diffs the dependency graph between cfg.SinceRef and cfg.UntilRef.

--- a/chronicle/release/description.go
+++ b/chronicle/release/description.go
@@ -40,14 +40,14 @@ type Description struct {
 	// version bump). Optional, populated by the worker when toolchain detection is
 	// enabled and a requirement changed. Rendered as a rollup within the
 	// Dependencies section, so it travels alongside DependencyDiff.
-	Toolchain *ToolchainData
+	Toolchain *ToolchainData `json:",omitempty"`
 
 	// raw evidence totals (pre-filter), surfaced for the summary report so it
 	// can show "N (M kept)" trailers. Populated by the worker after the
 	// summarizer runs; zero when not provided.
-	PRTotal     int
-	IssueTotal  int
-	CommitTotal int
+	PRTotal     int `json:"-"`
+	IssueTotal  int `json:"-"`
+	CommitTotal int `json:"-"`
 }
 
 // HasDependencyContent reports whether the Dependencies section has anything to

--- a/chronicle/release/releasers/github/gh_pull_request.go
+++ b/chronicle/release/releasers/github/gh_pull_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/scylladb/go-set/strset"
@@ -239,6 +240,26 @@ func prsWithoutLabel(labels ...string) prFilter {
 					return false
 				}
 			}
+		}
+
+		return true
+	}
+}
+
+// prsWithoutAuthor drops PRs whose author login matches any of the given names.
+// The match is case-insensitive and ignores a trailing "[bot]" suffix so that
+// "dependabot" matches the GitHub login "dependabot[bot]".
+func prsWithoutAuthor(authors ...string) prFilter {
+	want := strset.New()
+	for _, a := range authors {
+		want.Add(strings.ToLower(a))
+	}
+	return func(pr ghPullRequest, ctx ...*string) bool {
+		login := strings.TrimSuffix(strings.ToLower(pr.Author), "[bot]")
+		if want.Has(login) {
+			setReason(ctx, "author:excluded:"+pr.Author)
+			log.Tracef("PR #%d filtered out: excluded author %q", pr.Number, pr.Author)
+			return false
 		}
 
 		return true

--- a/chronicle/release/releasers/github/gh_pull_request_test.go
+++ b/chronicle/release/releasers/github/gh_pull_request_test.go
@@ -201,6 +201,57 @@ func Test_prsWithoutLabel(t *testing.T) {
 	}
 }
 
+func Test_prsWithoutAuthor(t *testing.T) {
+	tests := []struct {
+		name    string
+		pr      ghPullRequest
+		authors []string
+		keep    bool
+	}{
+		{
+			name:    "matches bot login with [bot] suffix",
+			authors: []string{"dependabot"},
+			pr:      ghPullRequest{Author: "dependabot[bot]"},
+			keep:    false,
+		},
+		{
+			name:    "matches bare login",
+			authors: []string{"dependabot"},
+			pr:      ghPullRequest{Author: "dependabot"},
+			keep:    false,
+		},
+		{
+			name:    "match is case-insensitive",
+			authors: []string{"Dependabot"},
+			pr:      ghPullRequest{Author: "dependabot[bot]"},
+			keep:    false,
+		},
+		{
+			name:    "matches any of several authors",
+			authors: []string{"dependabot", "renovate"},
+			pr:      ghPullRequest{Author: "renovate[bot]"},
+			keep:    false,
+		},
+		{
+			name:    "does not match a normal author",
+			authors: []string{"dependabot", "renovate"},
+			pr:      ghPullRequest{Author: "octocat"},
+			keep:    true,
+		},
+		{
+			name:    "empty author list keeps everything",
+			authors: nil,
+			pr:      ghPullRequest{Author: "dependabot[bot]"},
+			keep:    true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.keep, prsWithoutAuthor(test.authors...)(test.pr))
+		})
+	}
+}
+
 func Test_prsWithoutClosedLinkedIssue(t *testing.T) {
 	tests := []struct {
 		name string

--- a/chronicle/release/releasers/github/summarizer.go
+++ b/chronicle/release/releasers/github/summarizer.go
@@ -35,9 +35,13 @@ type Config struct {
 	IncludeUnlabeledIssues          bool
 	IncludeUnlabeledPRs             bool
 	ExcludeLabels                   []string
-	ChangeTypesByLabel              change.TypeSet
-	IssuesRequireLinkedPR           bool
-	ConsiderPRMergeCommits          bool
+	// ExcludeAuthors drops PRs authored by any of these logins (case-insensitive,
+	// "[bot]" suffix ignored). Used to suppress dependency-bot PRs when the
+	// dependencies section already reports those bumps.
+	ExcludeAuthors         []string
+	ChangeTypesByLabel     change.TypeSet
+	IssuesRequireLinkedPR  bool
+	ConsiderPRMergeCommits bool
 
 	// InferChangeTypeFromTitle, when true, infers a change type from a PR's
 	// conventional-commit title prefix when the PR carries no change-type label.
@@ -808,6 +812,7 @@ func changesFromUnlabeledPRs(config Config, allMergedPRs []ghPullRequest, sinceT
 		// a PR whose change type was inferred from its title is carried by the
 		// standard (typed) PR path; exclude it here so it isn't counted twice.
 		prsWithoutChangeType(config),
+		prsWithoutAuthor(config.ExcludeAuthors...),
 	}
 
 	filters = append(filters, standardChronologicalPrFilters(config, sinceTag, untilTag, includeCommits)...)
@@ -951,6 +956,7 @@ func standardQualitativePrFilters(config Config) []prFilter {
 		// or (when enabled) an inferred conventional-commit title prefix.
 		prsWithChangeTypes(config),
 		prsWithoutLabel(config.ExcludeLabels...),
+		prsWithoutAuthor(config.ExcludeAuthors...),
 		// Merged PRs linked to closed issues should be hidden so that the closed issue title takes precedence over the pr title
 		prsWithoutClosedLinkedIssue(),
 		// Merged PRs with open issues indicates a partial implementation. When the last PR is merged for the issue

--- a/chronicle/release/toolchain.go
+++ b/chronicle/release/toolchain.go
@@ -6,8 +6,8 @@ import "github.com/anchore/chronicle/chronicle/dependency"
 // until refs (e.g. a bump to the minimum Go version in go.mod). It is populated only when
 // toolchain detection is enabled and at least one requirement changed.
 type ToolchainData struct {
-	Updates  []ToolchainUpdate  // each detected requirement change
-	Warnings []ToolchainWarning // reconciliation issues; surfaced to operators and JSON output, never the changelog body
+	Updates  []ToolchainUpdate  `json:",omitempty"` // each detected requirement change
+	Warnings []ToolchainWarning `json:",omitempty"` // reconciliation issues; surfaced to operators and JSON output, never the changelog body
 }
 
 // ToolchainDirection indicates whether a requirement moved up or down between refs. It is empty

--- a/cmd/chronicle/cli/commands/create_github_worker.go
+++ b/cmd/chronicle/cli/commands/create_github_worker.go
@@ -32,7 +32,7 @@ func createChangelogFromGithub(ctx context.Context, appConfig *createConfig) (*r
 		return nil, nil, err
 	}
 
-	ghConfig := appConfig.Github.ToGithubConfig()
+	ghConfig := buildGithubConfig(appConfig)
 
 	gitter, err := git.New(appConfig.RepoPath)
 	if err != nil {
@@ -116,6 +116,17 @@ func createChangelogFromGithub(ctx context.Context, appConfig *createConfig) (*r
 	enrichDescription(ctx, appConfig, gitter, startRelease, untilTag, description, evidence, dbRefresh, vulnLeaf)
 
 	return startRelease, description, nil
+}
+
+// buildGithubConfig derives the summarizer config from app config, suppressing
+// dependency-bot PRs when the dependencies section is enabled since it reports
+// those bumps directly (avoids double-reporting).
+func buildGithubConfig(appConfig *createConfig) github.Config {
+	ghConfig := appConfig.Github.ToGithubConfig()
+	if appConfig.Dependencies.Enabled() {
+		ghConfig.ExcludeAuthors = append(ghConfig.ExcludeAuthors, "dependabot", "renovate")
+	}
+	return ghConfig
 }
 
 // enrichDescription runs the two opt-in, description-enriching diffs concurrently.


### PR DESCRIPTION
This will remove any PRs from consideration that were authored by dependabot or renovate when we are using `--dependencies` flag to have Syft do the work of finding the package diff.