### PR TITLE
Gracefully degrade grype functionality

### DIFF
--- a/chronicle/dependency/scan/db.go
+++ b/chronicle/dependency/scan/db.go
@@ -1,7 +1,6 @@
 package scan
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -25,34 +24,25 @@ type DB struct {
 	provider vulnerability.Provider
 }
 
-// DBStale reports whether the locally-installed grype vulnerability DB is missing
-// or was built more than maxAge ago. It reads the on-disk DB description only — no
-// network — so the caller can decide whether to spend time updating before the
-// (potentially slow, networked) LoadDB. A missing DB reports stale=true; an
-// unreadable DB reports stale=true with the error so the caller can still choose
-// to attempt a refresh.
-func DBStale(maxAge time.Duration) (stale bool, err error) {
+// DBStatus reports the on-disk grype DB state without any network access.
+// present is false when no DB is installed or its status is unreadable; age is
+// how long ago it was built (meaningful only when present). The caller uses this
+// to decide whether to update (when enabled) and whether to warn about staleness.
+func DBStatus() (present bool, age time.Duration) {
 	desc, err := v6.ReadDescription(installation.DefaultConfig(grypeID).DBFilePath())
-	if err != nil {
-		if errors.Is(err, v6.ErrDBDoesNotExist) {
-			return true, nil
-		}
-		return true, fmt.Errorf("unable to read vulnerability DB status: %w", err)
+	if err != nil || desc == nil {
+		return false, 0
 	}
-	return time.Since(desc.Built.Time) > maxAge, nil
+	return true, time.Since(desc.Built.Time)
 }
 
 // LoadDB loads the grype vulnerability DB into a provider the scanner matches
 // against. When update is set it first downloads the latest DB (the slow, network
-// step); otherwise it opens the on-disk DB directly. A local-only load is retried
-// with an update if grype rejects the on-disk DB (e.g. it aged past grype's own
-// max-allowed age between the staleness check and here), so a stale DB never
-// fails the load outright.
+// step); otherwise it opens whatever DB is on disk directly. The on-disk DB is
+// loaded regardless of its age (see loadProvider) — staleness is the caller's
+// concern to warn about, not an error here.
 func LoadDB(update bool) (*DB, error) {
 	provider, err := loadProvider(update)
-	if err != nil && !update {
-		provider, err = loadProvider(true)
-	}
 	if err != nil {
 		return nil, fmt.Errorf("unable to load vulnerability DB: %w", err)
 	}
@@ -60,6 +50,11 @@ func LoadDB(update bool) (*DB, error) {
 }
 
 func loadProvider(update bool) (vulnerability.Provider, error) {
-	provider, _, err := grype.LoadVulnerabilityDB(distribution.DefaultConfig(), installation.DefaultConfig(grypeID), update)
+	installCfg := installation.DefaultConfig(grypeID)
+	// don't let an over-age on-disk DB turn into a load error: chronicle decides
+	// whether to update (when enabled) and warns on staleness itself. Checksum
+	// validation stays on, so a genuinely corrupt DB still errors (→ degrade).
+	installCfg.ValidateAge = false
+	provider, _, err := grype.LoadVulnerabilityDB(distribution.DefaultConfig(), installCfg, update)
 	return provider, err
 }

--- a/cmd/chronicle/cli/commands/create_github_worker.go
+++ b/cmd/chronicle/cli/commands/create_github_worker.go
@@ -172,20 +172,30 @@ func attachDependencyDiff(ctx context.Context, appConfig *createConfig, gitter g
 		return
 	}
 
-	annotate := appConfig.Dependencies.AnnotateVulnerabilities
+	configured := appConfig.Dependencies.AnnotateVulnerabilities
+	annotate := configured
+	// gracefully degrade when annotation was requested but no usable DB loaded
+	// (missing/corrupt, or a failed download): behave exactly as if
+	// annotate-vulnerabilities was never passed — packages-only, with the row
+	// skipped rather than failed. The cause was already warned at load time.
+	if configured && db == nil {
+		annotate = false
+		skipVulnLeaf(vulnLeaf)
+	}
 
 	// only-vulnerable is a render-time filter that only means anything once
-	// annotation has populated the vuln deltas. Resolve it once: gate it on
-	// annotation here, and warn if the user asked for it without annotation.
+	// annotation has populated the vuln deltas. Resolve it against the effective
+	// annotate state; warn only when the user asked for it without configuring
+	// annotation at all (a DB-unavailable degrade is already explained above).
 	onlyVulnerable := appConfig.Dependencies.OnlyVulnerable && annotate
-	if appConfig.Dependencies.OnlyVulnerable && !onlyVulnerable {
+	if appConfig.Dependencies.OnlyVulnerable && !configured {
 		log.Warn("dependencies.only-vulnerable has no effect without annotate-vulnerabilities; showing all changes")
 	}
 
 	// remaining (carried-over) vulnerabilities likewise only exist once annotation
 	// has matched both refs; gate it the same way and warn on a no-op request.
 	showRemaining := appConfig.Dependencies.ShowRemainingVulnerabilities && annotate
-	if appConfig.Dependencies.ShowRemainingVulnerabilities && !showRemaining {
+	if appConfig.Dependencies.ShowRemainingVulnerabilities && !configured {
 		log.Warn("dependencies.show-remaining-vulnerabilities has no effect without annotate-vulnerabilities; omitting remaining vulnerabilities")
 	}
 
@@ -227,41 +237,47 @@ func attachDependencyDiff(ctx context.Context, appConfig *createConfig, gitter g
 }
 
 // vulnDBMaxAge is how stale the grype vulnerability DB may be before chronicle
-// refreshes it: a DB older than this (or missing) triggers a download. Matches
-// grype's own max-allowed DB age.
+// acts on it: when DB updates are enabled, a DB older than this (or missing)
+// triggers a download; when updates are disabled, an older DB is used as-is with
+// a warning. Matches grype's own max-allowed DB age.
 const vulnDBMaxAge = 5 * 24 * time.Hour
 
 // startVulnDBRefresh loads the grype vulnerability DB in the background so a
 // (possibly slow) download overlaps the commit/issue/PR fetch. It returns nil
-// when vulnerability annotation is off. A missing or stale DB spins the
-// "vulnerabilities" row on "updating DB" while it downloads (replacing the idle
-// "waiting"); a current DB just loads locally, leaving the row untouched until
-// matching. awaitVulnDB joins the loaded DB before the dependency scan matches —
-// the row's matching/resolve states are driven later, as usual.
+// when vulnerability annotation is off. With DB updates enabled (the default), a
+// missing or stale DB spins the "vulnerabilities" row on "updating DB" while it
+// downloads; with updates disabled, the on-disk DB is loaded as-is and a stale
+// one only logs a warning (a missing/unusable DB then degrades to packages-only).
+// awaitVulnDB joins the loaded DB before the dependency scan matches — the row's
+// matching/resolve states are driven later, as usual.
 func startVulnDBRefresh(appConfig *createConfig, vulnLeaf *event.Leaf) <-chan *scan.DB {
 	if !appConfig.Dependencies.AnnotateVulnerabilities || !appConfig.Dependencies.Enabled() {
 		return nil
 	}
 
-	// a quick, local status read (no network) decides whether the slow update is
-	// needed; only then do we light up the row, so it reads "updating DB" only
-	// when grype actually downloads. SetStage flips the pending row to running.
-	stale, err := scan.DBStale(vulnDBMaxAge)
-	if err != nil {
-		log.WithFields("error", err).Trace("unable to determine vulnerability DB age; refreshing")
-		stale = true
-	}
-	if stale {
+	// a quick, local status read (no network) decides whether to update and/or
+	// warn. We only download when the DB is stale/missing AND updates are enabled;
+	// otherwise a stale-but-present DB is used as-is with a warning.
+	present, age := scan.DBStatus()
+	stale := !present || age > vulnDBMaxAge
+	update := stale && appConfig.Dependencies.UpdateVulnerabilityDB
+	switch {
+	case update:
+		// light up the row only when grype actually downloads; SetStage flips the
+		// pending row to running.
 		vulnLeaf.SetStage("updating DB")
+	case present && age > vulnDBMaxAge:
+		log.WithFields("age", age.Round(time.Hour).String()).
+			Warn("vulnerability DB is older than the max recommended age and DB updates are disabled; results may be stale")
 	}
 
 	ch := make(chan *scan.DB, 1)
 	go func() {
-		db, err := scan.LoadDB(stale)
+		db, err := scan.LoadDB(update)
 		if err != nil {
 			// non-fatal: the scan degrades to packages-only and the vulnerability
-			// row is failed downstream (nil Vulns → errVulnMatchIncomplete).
-			log.WithFields("error", err).Warn("unable to load vulnerability DB; skipping vulnerability matching")
+			// row is skipped downstream (db is nil → attachDependencyDiff degrades).
+			log.WithFields("error", err).Warn("unable to load vulnerability DB; continuing without vulnerability annotations")
 		}
 		ch <- db
 	}()
@@ -276,6 +292,17 @@ func awaitVulnDB(ch <-chan *scan.DB) *scan.DB {
 		return nil
 	}
 	return <-ch
+}
+
+// skipVulnLeaf marks the "vulnerabilities" row and its since/until branches as
+// skipped so they read as intentionally-not-done (⊘) rather than being promoted
+// to a hollow resolved checkmark when the tree closes. Used when annotation was
+// requested but no usable DB loaded, so the run degrades to packages-only.
+func skipVulnLeaf(vulnLeaf *event.Leaf) {
+	for _, child := range vulnLeaf.Children() {
+		child.Skip()
+	}
+	vulnLeaf.Skip()
 }
 
 // finalizeVulnLeaf is a safety net for the "vulnerabilities" row: the DB refresh

--- a/cmd/chronicle/cli/options/dependencies.go
+++ b/cmd/chronicle/cli/options/dependencies.go
@@ -14,6 +14,7 @@ type Dependencies struct {
 	Ecosystems                   []string          `yaml:"ecosystems" json:"ecosystems" mapstructure:"ecosystems"`
 	Exclude                      []string          `yaml:"exclude" json:"exclude" mapstructure:"exclude"`
 	AnnotateVulnerabilities      bool              `yaml:"annotate-vulnerabilities" json:"annotate-vulnerabilities" mapstructure:"annotate-vulnerabilities"`
+	UpdateVulnerabilityDB        bool              `yaml:"update-vulnerability-db" json:"update-vulnerability-db" mapstructure:"update-vulnerability-db"`
 	OnlyVulnerable               bool              `yaml:"only-vulnerable" json:"only-vulnerable" mapstructure:"only-vulnerable"`
 	ShowRemainingVulnerabilities bool              `yaml:"show-remaining-vulnerabilities" json:"show-remaining-vulnerabilities" mapstructure:"show-remaining-vulnerabilities"`
 	MinSeverity                  string            `yaml:"min-severity" json:"min-severity" mapstructure:"min-severity"`
@@ -57,6 +58,7 @@ func (c *Dependencies) DescribeFields(descriptions clio.FieldDescriptionSet) {
 	descriptions.Add(&c.Ecosystems, "ecosystems to scan (syft cataloger selection, e.g. language, go, python); 'auto' detects ecosystems from root manifests, 'none' disables (wins over all); enables the feature when set")
 	descriptions.Add(&c.Exclude, "paths to exclude from dependency scanning (syft exclude patterns; each must start with ./, */, or **/, e.g. ./vendor, **/testdata)")
 	descriptions.Add(&c.AnnotateVulnerabilities, "annotate dependency changes with known vulnerability information")
+	descriptions.Add(&c.UpdateVulnerabilityDB, "download the latest grype vulnerability DB when the installed one is missing or older than 5 days; when disabled, use whatever DB is installed (warning if it is stale) and skip vulnerability annotation entirely if none is usable")
 	descriptions.Add(&c.OnlyVulnerable, "only show dependency changes that remediated or introduced a vulnerability (requires annotate-vulnerabilities)")
 	descriptions.Add(&c.ShowRemainingVulnerabilities, "show the remaining (carried-over) vulnerabilities still present in the latest scan that this release did not remediate, as a rollup (requires annotate-vulnerabilities)")
 	descriptions.Add(&c.MinSeverity, "minimum vulnerability severity to include in annotations (e.g. low, medium, high, critical)")
@@ -83,9 +85,12 @@ var _ clio.FieldDescriber = (*DependencyActions)(nil)
 // collapse (e.g. slack, md-pretty) so no section is reduced to a bare count.
 func DefaultDependencies() Dependencies {
 	return Dependencies{
-		Ecosystems:                   nil,
-		Exclude:                      nil,
-		AnnotateVulnerabilities:      false,
+		Ecosystems:              nil,
+		Exclude:                 nil,
+		AnnotateVulnerabilities: false,
+		// updates ride on annotation; on by default so a stale/missing DB is refreshed
+		// without extra flags. Disable to use whatever DB is installed (warn if stale).
+		UpdateVulnerabilityDB:        true,
 		OnlyVulnerable:               false,
 		ShowRemainingVulnerabilities: false,
 		MinSeverity:                  "",


### PR DESCRIPTION
Lets you turn off grype's vulnerability DB auto-updates and just run against whatever DB is already on disk. Handy for air-gapped/offline or CI setups where you don't want chronicle reaching out to download a fresh DB mid-run.

- new `dependencies.update-vulnerability-db` option (CLI flag + config), defaults to `true` so nothing changes unless you opt out
- with updates on (the default): a missing or >5-day-old DB still triggers a download, same as before
- with updates off: chronicle uses the installed DB as-is, and just logs a warning (with the DB's age) when it's older than 5 days instead of failing or downloading
- if there's no usable DB at all (missing/corrupt, or a download that failed), it now gracefully degrades to a packages-only diff... exactly as if `--vulnerabilities` was never passed — with a warning in the log
- the "vulnerabilities" row in the TUI shows as skipped (⊘) in that case rather than a red failure

Under the hood grype's `ValidateAge` is now off so a stale on-disk DB loads instead of erroring (that 5-day age check is what used to force the download), chronicle owns the staleness warning itself, and the old "retry with a forced update" fallback in `LoadDB` is gone since it's no longer needed.