### PR TITLE
Add dependencies recurse option

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,12 @@ dependencies:
   # matched relative to the repo root — e.g. ./vendor, **/testdata, */examples.
   exclude: []
 
+  # recurse into subdirectories when scanning for dependency and toolchain
+  # manifests. false (the default) scans only the repository root, so a manifest
+  # in a subdir (e.g. a tooling .make/go.mod) does not leak into the changelog.
+  # set true to scan the whole tree. (config-only, no flag)
+  recursive: false
+
   # annotate dependency changes with known vulnerability information
   # same as --vulnerabilities. requires at least one ecosystem above (there is
   # nothing to annotate without a dependency diff).

--- a/chronicle/dependency/diff_compute_test.go
+++ b/chronicle/dependency/diff_compute_test.go
@@ -42,7 +42,7 @@ require github.com/google/uuid v1.6.0
 	sinceSha, _ := buildGoModRepo(t, repoDir, goModBase, goModBumped)
 
 	result, err := dependency.ComputeDiff(context.Background(),
-		scan.NewScanner(source.NewGitTarget(repoDir), "", nil, nil, nil),
+		scan.NewScanner(source.NewGitTarget(repoDir), "", nil, nil, true, nil),
 		dependency.DiffConfig{
 			Comparer: scan.NewVersionComparer(),
 			SinceRef: sinceSha,

--- a/chronicle/dependency/scan/scan.go
+++ b/chronicle/dependency/scan/scan.go
@@ -9,6 +9,7 @@ package scan
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -45,6 +46,7 @@ type scanner struct {
 	sourceName   string        // project name, so syft derives a stable artifact ID per ref
 	ecosystems   []string      // syft cataloger selection expressions (e.g. "language", "go")
 	excludePaths []string      // syft exclude patterns (each must start with ./, */, or **/)
+	recursive    bool          // when false, scan only the root dir (top-level subdirs are pruned)
 
 	// provider is the loaded grype vulnerability DB to match against; nil means
 	// packages-only (no matching).
@@ -62,15 +64,18 @@ var getSourceMu sync.Mutex
 // ref. ecosystems are syft cataloger selection expressions that scope cataloging
 // (e.g. ["language"] or ["go"]); empty means syft's default directory catalogers.
 // excludePaths are syft exclude patterns that prune directories from the scan
-// (each must start with ./, */, or **/); empty means scan everything. db is the
+// (each must start with ./, */, or **/); empty means scan everything. recursive
+// controls scan depth: when false, only the root dir is cataloged (every
+// top-level subdir is pruned); when true, the whole tree is scanned. db is the
 // loaded vulnerability DB to match against (from LoadDB); nil means scan packages
 // only.
-func NewScanner(target source.Target, sourceName string, ecosystems, excludePaths []string, db *DB) dependency.Scanner {
+func NewScanner(target source.Target, sourceName string, ecosystems, excludePaths []string, recursive bool, db *DB) dependency.Scanner {
 	s := &scanner{
 		target:       target,
 		sourceName:   sourceName,
 		ecosystems:   ecosystems,
 		excludePaths: excludePaths,
+		recursive:    recursive,
 	}
 	if db != nil {
 		s.provider = db.provider
@@ -126,16 +131,22 @@ func (s *scanner) scanDir(ctx context.Context, dir, ref string) (dependency.Scan
 // consumes), linking the resolved syft source to the bus so the UI can attribute
 // live cataloging progress to the right ref.
 func (s *scanner) catalog(ctx context.Context, dir, ref string) (*catalog, error) {
-	if len(s.excludePaths) > 0 {
+	if len(s.excludePaths) > 0 || !s.recursive {
 		// syft resolves symlinks when indexing the tree but derives exclusion
 		// roots from filepath.Abs (no symlink resolution), so when the scan dir
 		// sits behind a symlink (e.g. macOS /var → /private/var tmpdirs) the
 		// patterns silently match nothing. Canonicalize the root up front so the
 		// exclusions line up with the indexed paths. Best-effort: on error keep the
-		// original path (exclusions may simply not apply).
+		// original path (exclusions may simply not apply). Done before deriving the
+		// non-recursive prunes below so their names match the indexed paths too.
 		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
 			dir = resolved
 		}
+	}
+
+	excludes, err := s.effectiveExcludes(dir)
+	if err != nil {
+		return nil, err
 	}
 
 	srcCfg := syft.DefaultGetSourceConfig()
@@ -145,11 +156,11 @@ func (s *scanner) catalog(ctx context.Context, dir, ref string) (*catalog, error
 		// name and version provided for directory source" warning).
 		srcCfg = srcCfg.WithAlias(syftSource.Alias{Name: s.sourceName, Version: ref})
 	}
-	if len(s.excludePaths) > 0 {
+	if len(excludes) > 0 {
 		// prune the requested paths from the index before cataloging (e.g. vendored
-		// or test trees). Patterns are relative to the scan root and resolved by
-		// syft's directory source.
-		srcCfg = srcCfg.WithExcludeConfig(syftSource.ExcludeConfig{Paths: s.excludePaths})
+		// or test trees, plus every top-level subdir when non-recursive). Patterns
+		// are relative to the scan root and resolved by syft's directory source.
+		srcCfg = srcCfg.WithExcludeConfig(syftSource.ExcludeConfig{Paths: excludes})
 	}
 
 	getSourceMu.Lock()
@@ -186,6 +197,34 @@ func (s *scanner) catalog(ctx context.Context, dir, ref string) (*catalog, error
 	}
 
 	return &catalog{packages: mapPackages(sb), sb: sb}, nil
+}
+
+// effectiveExcludes combines the user's exclude patterns with the synthetic
+// prunes that enforce non-recursive scanning. No single syft glob can express
+// "root only" — a depth-1 pattern (e.g. "*") also matches root files, which the
+// directory source can't distinguish from dirs — so instead we read the root's
+// top-level entries and emit one "./<name>" prune per subdir. syft's directory
+// source matches each against the indexed path and returns filepath.SkipDir for
+// the dir, pruning the whole subtree while leaving root files untouched. dir is
+// expected to already be symlink-resolved by the caller.
+func (s *scanner) effectiveExcludes(dir string) ([]string, error) {
+	if s.recursive {
+		return s.excludePaths, nil
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read scan root %q for non-recursive pruning: %w", dir, err)
+	}
+
+	// preserve the user's patterns, then prune every top-level subdir.
+	excludes := append([]string(nil), s.excludePaths...)
+	for _, e := range entries {
+		if e.IsDir() {
+			excludes = append(excludes, "./"+e.Name())
+		}
+	}
+	return excludes, nil
 }
 
 // mapPackages folds syft's package collection into the pure dependency.Package

--- a/chronicle/dependency/scan/scan_test.go
+++ b/chronicle/dependency/scan/scan_test.go
@@ -22,29 +22,49 @@ func TestScanner_Scan_Exclude(t *testing.T) {
 	writeManifest(t, filepath.Join(root, "pkg", "testdata", "requirements.txt"), "testdep==3.0.0")
 
 	tests := []struct {
-		name     string
-		exclude  []string
-		wantPkgs []string
+		name      string
+		recursive bool
+		exclude   []string
+		wantPkgs  []string
 	}{
 		{
-			name:     "no excludes scans everything",
-			exclude:  nil,
-			wantPkgs: []string{"rootdep", "testdep", "vendordep"},
+			name:      "no excludes scans everything",
+			recursive: true,
+			exclude:   nil,
+			wantPkgs:  []string{"rootdep", "testdep", "vendordep"},
 		},
 		{
-			name:     "exclude a top-level dir",
-			exclude:  []string{"./vendor"},
-			wantPkgs: []string{"rootdep", "testdep"},
+			name:      "exclude a top-level dir",
+			recursive: true,
+			exclude:   []string{"./vendor"},
+			wantPkgs:  []string{"rootdep", "testdep"},
 		},
 		{
-			name:     "exclude a nested dir by glob",
-			exclude:  []string{"**/testdata"},
-			wantPkgs: []string{"rootdep", "vendordep"},
+			name:      "exclude a nested dir by glob",
+			recursive: true,
+			exclude:   []string{"**/testdata"},
+			wantPkgs:  []string{"rootdep", "vendordep"},
 		},
 		{
-			name:     "multiple excludes",
-			exclude:  []string{"./vendor", "**/testdata"},
-			wantPkgs: []string{"rootdep"},
+			name:      "multiple excludes",
+			recursive: true,
+			exclude:   []string{"./vendor", "**/testdata"},
+			wantPkgs:  []string{"rootdep"},
+		},
+		{
+			// non-recursive prunes every top-level subdir while keeping root files,
+			// regardless of how deeply the subdir manifests are nested.
+			name:      "non-recursive scans only the root",
+			recursive: false,
+			exclude:   nil,
+			wantPkgs:  []string{"rootdep"},
+		},
+		{
+			// user excludes still compose with the synthetic subdir prunes.
+			name:      "non-recursive with a user exclude",
+			recursive: false,
+			exclude:   []string{"./vendor"},
+			wantPkgs:  []string{"rootdep"},
 		},
 	}
 
@@ -54,7 +74,7 @@ func TestScanner_Scan_Exclude(t *testing.T) {
 			// full syft catalog/exclude/symlink path without materializing a git
 			// ref (no target needed). annotate is off (nil dbReady), so this
 			// returns packages only.
-			s := &scanner{sourceName: "test", ecosystems: []string{"python"}, excludePaths: tt.exclude}
+			s := &scanner{sourceName: "test", ecosystems: []string{"python"}, excludePaths: tt.exclude, recursive: tt.recursive}
 			snap, err := s.scanDir(context.Background(), root, "v0")
 			require.NoError(t, err)
 

--- a/chronicle/dependency/toolchain/config.go
+++ b/chronicle/dependency/toolchain/config.go
@@ -12,6 +12,9 @@ type Config struct {
 	Ignore []string
 	// Paths maps an ecosystem to its discovery globs, overriding the detector default.
 	Paths map[dependency.Ecosystem][]string
+	// Recursive controls discovery depth. When false (default), only root-level manifests are
+	// considered; any path in a subdirectory is ignored regardless of the per-ecosystem globs.
+	Recursive bool
 }
 
 // DefaultIgnore returns the path globs excluded from toolchain source discovery by default, so a

--- a/chronicle/dependency/toolchain/detect_test.go
+++ b/chronicle/dependency/toolchain/detect_test.go
@@ -20,8 +20,9 @@ func TestDetect(t *testing.T) {
 	// default ignore set; individual tests tweak copies of this.
 	baseCfg := func() Config {
 		return Config{
-			Enabled: true,
-			Ignore:  []string{"**/vendor/**", "**/testdata/**"},
+			Enabled:   true,
+			Recursive: true,
+			Ignore:    []string{"**/vendor/**", "**/testdata/**"},
 		}
 	}
 
@@ -147,6 +148,27 @@ func TestDetect(t *testing.T) {
 			want: nil,
 		},
 		{
+			// default (non-recursive) discovery: the root go.mod bump is reported, the nested
+			// tools/go.mod bump is not, without any explicit path override.
+			name:  "non-recursive discovers only root manifests",
+			cfg:   Config{Enabled: true, Ignore: []string{"**/vendor/**", "**/testdata/**"}},
+			since: "v1",
+			until: "v2",
+			sinceFiles: []git.FileBlob{
+				{Path: "go.mod", Content: goMod("1.21")},
+				{Path: "tools/go.mod", Content: goMod("1.20")},
+			},
+			untilFiles: []git.FileBlob{
+				{Path: "go.mod", Content: goMod("1.23")},
+				{Path: "tools/go.mod", Content: goMod("1.22")},
+			},
+			want: &release.ToolchainData{
+				Updates: []release.ToolchainUpdate{
+					{Tool: "go", Source: "go directive", File: "go.mod", From: "1.21", To: "1.23", Direction: release.ToolchainUpgrade},
+				},
+			},
+		},
+		{
 			name:       "explicit ecosystem selection runs only requested",
 			cfg:        Config{Enabled: true, Ecosystems: []dependency.Ecosystem{dependency.EcosystemGo}},
 			since:      "v1",
@@ -179,7 +201,7 @@ func TestDetect(t *testing.T) {
 		},
 		{
 			name:  "explicit path override narrows discovery to root",
-			cfg:   Config{Enabled: true, Paths: map[dependency.Ecosystem][]string{dependency.EcosystemGo: {"go.mod"}}},
+			cfg:   Config{Enabled: true, Recursive: true, Paths: map[dependency.Ecosystem][]string{dependency.EcosystemGo: {"go.mod"}}},
 			since: "v1",
 			until: "v2",
 			sinceFiles: []git.FileBlob{

--- a/chronicle/dependency/toolchain/dirty_test.go
+++ b/chronicle/dependency/toolchain/dirty_test.go
@@ -31,13 +31,19 @@ func TestDirtySourceFiles(t *testing.T) {
 		},
 		{
 			name:  "matches nested module manifests",
-			cfg:   Config{Enabled: true},
+			cfg:   Config{Enabled: true, Recursive: true},
 			dirty: []string{"tools/go.mod", "internal/foo.go"},
 			want:  []string{"tools/go.mod"},
 		},
 		{
+			name:  "non-recursive ignores nested module manifests",
+			cfg:   Config{Enabled: true},
+			dirty: []string{"go.mod", "tools/go.mod"},
+			want:  []string{"go.mod"},
+		},
+		{
 			name:  "ignored paths are not flagged",
-			cfg:   Config{Enabled: true, Ignore: []string{"**/vendor/**"}},
+			cfg:   Config{Enabled: true, Recursive: true, Ignore: []string{"**/vendor/**"}},
 			dirty: []string{"vendor/dep/go.mod"},
 			want:  nil,
 		},
@@ -49,7 +55,7 @@ func TestDirtySourceFiles(t *testing.T) {
 		},
 		{
 			name:  "path override narrows matching",
-			cfg:   Config{Enabled: true, Paths: map[dependency.Ecosystem][]string{dependency.EcosystemGo: {"go.mod"}}},
+			cfg:   Config{Enabled: true, Recursive: true, Paths: map[dependency.Ecosystem][]string{dependency.EcosystemGo: {"go.mod"}}},
 			dirty: []string{"tools/go.mod"},
 			want:  nil,
 		},

--- a/chronicle/dependency/toolchain/matcher.go
+++ b/chronicle/dependency/toolchain/matcher.go
@@ -1,11 +1,14 @@
 package toolchain
 
+import "strings"
+
 // matcher routes file paths to the detector responsible for them, honoring per-ecosystem path
 // globs and the global ignore list. It is built once per detection run so each git ref is walked
 // a single time.
 type matcher struct {
-	ecos   []ecosystemPaths
-	ignore []string
+	ecos      []ecosystemPaths
+	ignore    []string
+	recursive bool
 }
 
 type ecosystemPaths struct {
@@ -14,7 +17,7 @@ type ecosystemPaths struct {
 }
 
 func newMatcher(detectors []Detector, cfg Config) *matcher {
-	m := &matcher{ignore: cfg.Ignore}
+	m := &matcher{ignore: cfg.Ignore, recursive: cfg.Recursive}
 	for _, d := range detectors {
 		globs := cfg.Paths[d.Tool()]
 		if len(globs) == 0 {
@@ -35,6 +38,11 @@ func (m *matcher) match(p string) bool {
 // nil. An explicitly-listed path wins over an ignore glob only when it is not itself a glob match
 // against the ignore set; ignore is applied first to keep discovery quiet by default.
 func (m *matcher) detectorFor(p string) Detector {
+	// non-recursive discovery: a manifest in any subdirectory is out of scope, so reject anything
+	// below the root regardless of the per-ecosystem globs (which default to recursive "**/...").
+	if !m.recursive && strings.Contains(strings.TrimPrefix(p, "./"), "/") {
+		return nil
+	}
 	if m.isIgnored(p) {
 		return nil
 	}

--- a/cmd/chronicle/cli/commands/create_github_worker.go
+++ b/cmd/chronicle/cli/commands/create_github_worker.go
@@ -211,7 +211,7 @@ func attachDependencyDiff(ctx context.Context, appConfig *createConfig, gitter g
 	// the scanner owns materialization (the git Target) and matches against the
 	// pre-loaded DB (refreshed in parallel with the GitHub fetch); a nil db scans
 	// packages only, and ComputeDiff infers whether to attribute from the data.
-	scanner := scan.NewScanner(source.NewGitTarget(appConfig.RepoPath), sourceName, ecosystems, appConfig.Dependencies.Exclude, db)
+	scanner := scan.NewScanner(source.NewGitTarget(appConfig.RepoPath), sourceName, ecosystems, appConfig.Dependencies.Exclude, appConfig.Dependencies.Recursive, db)
 	result, err := dependency.ComputeDiff(ctx, scanner, dependency.DiffConfig{
 		Comparer:    scan.NewVersionComparer(),
 		SinceRef:    sinceRef,
@@ -453,6 +453,7 @@ func toolchainConfig(appConfig *createConfig) toolchain.Config {
 		Enabled:    true,
 		Ecosystems: ecos,
 		Ignore:     append(toolchain.DefaultIgnore(), appConfig.Dependencies.Exclude...),
+		Recursive:  appConfig.Dependencies.Recursive,
 	}
 }
 

--- a/cmd/chronicle/cli/options/dependencies.go
+++ b/cmd/chronicle/cli/options/dependencies.go
@@ -13,6 +13,7 @@ import (
 type Dependencies struct {
 	Ecosystems                   []string          `yaml:"ecosystems" json:"ecosystems" mapstructure:"ecosystems"`
 	Exclude                      []string          `yaml:"exclude" json:"exclude" mapstructure:"exclude"`
+	Recursive                    bool              `yaml:"recursive" json:"recursive" mapstructure:"recursive"`
 	AnnotateVulnerabilities      bool              `yaml:"annotate-vulnerabilities" json:"annotate-vulnerabilities" mapstructure:"annotate-vulnerabilities"`
 	UpdateVulnerabilityDB        bool              `yaml:"update-vulnerability-db" json:"update-vulnerability-db" mapstructure:"update-vulnerability-db"`
 	OnlyVulnerable               bool              `yaml:"only-vulnerable" json:"only-vulnerable" mapstructure:"only-vulnerable"`
@@ -57,6 +58,7 @@ func (c Dependencies) Enabled() bool {
 func (c *Dependencies) DescribeFields(descriptions clio.FieldDescriptionSet) {
 	descriptions.Add(&c.Ecosystems, "ecosystems to scan (syft cataloger selection, e.g. language, go, python); 'auto' detects ecosystems from root manifests, 'none' disables (wins over all); enables the feature when set")
 	descriptions.Add(&c.Exclude, "paths to exclude from dependency scanning (syft exclude patterns; each must start with ./, */, or **/, e.g. ./vendor, **/testdata)")
+	descriptions.Add(&c.Recursive, "recurse into subdirectories when scanning for dependencies and toolchain manifests; when false (default) only the repository root is scanned")
 	descriptions.Add(&c.AnnotateVulnerabilities, "annotate dependency changes with known vulnerability information")
 	descriptions.Add(&c.UpdateVulnerabilityDB, "download the latest grype vulnerability DB when the installed one is missing or older than 5 days; when disabled, use whatever DB is installed (warning if it is stale) and skip vulnerability annotation entirely if none is usable")
 	descriptions.Add(&c.OnlyVulnerable, "only show dependency changes that remediated or introduced a vulnerability (requires annotate-vulnerabilities)")
@@ -85,8 +87,11 @@ var _ clio.FieldDescriber = (*DependencyActions)(nil)
 // collapse (e.g. slack, md-pretty) so no section is reduced to a bare count.
 func DefaultDependencies() Dependencies {
 	return Dependencies{
-		Ecosystems:              nil,
-		Exclude:                 nil,
+		Ecosystems: nil,
+		Exclude:    nil,
+		// scan only the repository root by default; subdir manifests (e.g. a
+		// vendored or tooling .make/go.mod) would otherwise leak into the diff.
+		Recursive:               false,
 		AnnotateVulnerabilities: false,
 		// updates ride on annotation; on by default so a stale/missing DB is refreshed
 		// without extra flags. Disable to use whatever DB is installed (warn if stale).

--- a/cmd/chronicle/cli/options/dependencies_test.go
+++ b/cmd/chronicle/cli/options/dependencies_test.go
@@ -1,0 +1,13 @@
+package options
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultDependencies_RootOnlyByDefault(t *testing.T) {
+	// dependency scanning must default to the repository root only; recursing into
+	// subdirs (e.g. a tooling .make/go.mod) is opt-in via recursive: true.
+	assert.False(t, DefaultDependencies().Recursive)
+}


### PR DESCRIPTION
Defaults to scanning dependencies only for the root dir, not subdirs. Optionally can be turned on with a config switch.