### PR TITLE
Don't suggest a next-version that already has a tag

### DIFF
--- a/chronicle/release/releasers/github/version_speculator.go
+++ b/chronicle/release/releasers/github/version_speculator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/anchore/chronicle/chronicle/release"
 	"github.com/anchore/chronicle/chronicle/release/change"
 	"github.com/anchore/chronicle/internal/git"
+	"github.com/anchore/chronicle/internal/log"
 )
 
 var _ release.VersionSpeculator = (*VersionSpeculator)(nil)
@@ -91,31 +92,58 @@ func (s VersionSpeculator) NextUniqueVersion(currentVersion string, changes chan
 	if err != nil {
 		return "", err
 	}
-retry:
+
+	taken := make(map[string]struct{}, len(tags))
+	for _, t := range tags {
+		taken[t.Name] = struct{}{}
+	}
+
+	// when the ideal version's tag is already taken (e.g. from a failed release that can't be
+	// rolled back in the go ecosystem) we must roll forward to the next unused version. we roll
+	// forward along the same field that the release bumped: a feature release rolls to the next
+	// minor (v0.13.0 -> v0.14.0, never v0.13.1) and a patch release rolls to the next patch
+	// (v0.13.1 -> v0.13.2). major releases are special: we never speculate a brand new major
+	// version, so a taken major rolls forward by minor instead (v2.0.0 -> v2.1.0).
+	bumpKind := s.effectiveBumpKind(changes)
+
 	for {
-		for _, t := range tags {
-			if t.Name == nextReleaseVersion {
-				// looks like there is already a tag for this speculative release, let's choose a patch variant of this
-				verObj, err := semver.NewVersion(strings.TrimLeft(nextReleaseVersion, "v"))
-				if err != nil {
-					return "", err
-				}
-				verObj.BumpPatch()
-
-				var prefix string
-				if strings.HasPrefix(nextReleaseVersion, "v") {
-					prefix = "v"
-				}
-
-				releaseVersionCandidate := prefix + verObj.String()
-
-				nextReleaseVersion = releaseVersionCandidate
-				continue retry
-			}
+		if _, ok := taken[nextReleaseVersion]; !ok {
+			break
 		}
-		// we've checked that there are no existing tags that match the next release
-		break
+
+		verObj, err := semver.NewVersion(strings.TrimLeft(nextReleaseVersion, "v"))
+		if err != nil {
+			return "", err
+		}
+
+		switch bumpKind {
+		case change.SemVerMinor, change.SemVerMajor:
+			verObj.BumpMinor()
+		default:
+			verObj.BumpPatch()
+		}
+
+		var prefix string
+		if strings.HasPrefix(nextReleaseVersion, "v") {
+			prefix = "v"
+		}
+
+		takenVersion := nextReleaseVersion
+		nextReleaseVersion = prefix + verObj.String()
+
+		log.WithFields("taken", takenVersion, "next", nextReleaseVersion).
+			Warnf("speculated release version %q already has a tag; rolling forward to %q", takenVersion, nextReleaseVersion)
 	}
 
 	return nextReleaseVersion, nil
+}
+
+// effectiveBumpKind reports the highest-significance semver field that the given changes would
+// bump, honoring EnforceV0 (which downgrades a major bump to a minor bump for v0.x projects).
+func (s VersionSpeculator) effectiveBumpKind(changes change.Changes) change.SemVerKind {
+	kind := change.Significance(changes)
+	if kind == change.SemVerMajor && s.EnforceV0 {
+		kind = change.SemVerMinor
+	}
+	return kind
 }

--- a/chronicle/release/releasers/github/version_speculator_test.go
+++ b/chronicle/release/releasers/github/version_speculator_test.go
@@ -205,11 +205,13 @@ func TestFindNextUniqueVersion(t *testing.T) {
 		wantErr             require.ErrorAssertionFunc
 	}{
 		{
-			name:    "bump major version -- major conflict",
-			release: "v0.1.5",
+			// a taken major version rolls forward by minor, never by major (we never
+			// speculate a brand new major version) and never by patch.
+			name:    "bump major version -- major conflict rolls forward by minor",
+			release: "v1.5.2",
 			git: git.MockInterface{
 				MockTags: []string{
-					"v1.0.0",
+					"v2.0.0",
 				},
 			},
 			changes: []change.Change{
@@ -217,7 +219,192 @@ func TestFindNextUniqueVersion(t *testing.T) {
 					ChangeTypes: []change.Type{majorChange, minorChange, patchChange},
 				},
 			},
-			want: "v1.0.1",
+			want: "v2.1.0",
+		},
+		{
+			name:    "bump major version -- multiple major conflicts roll forward by minor",
+			release: "v1.5.2",
+			git: git.MockInterface{
+				MockTags: []string{
+					"v2.0.0",
+					"v2.1.0",
+					"v2.2.0",
+				},
+			},
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{majorChange},
+				},
+			},
+			want: "v2.3.0",
+		},
+		{
+			// a taken feature (minor) version rolls forward by minor, not patch.
+			name:    "bump feature version -- minor conflict rolls forward by minor",
+			release: "v0.12.0",
+			git: git.MockInterface{
+				MockTags: []string{
+					"v0.13.0",
+				},
+			},
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{minorChange},
+				},
+			},
+			want: "v0.14.0",
+		},
+		{
+			name:    "bump feature version -- multiple minor conflicts roll forward by minor",
+			release: "v0.12.0",
+			git: git.MockInterface{
+				MockTags: []string{
+					"v0.13.0",
+					"v0.14.0",
+				},
+			},
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{minorChange},
+				},
+			},
+			want: "v0.15.0",
+		},
+		{
+			// a taken patch version rolls forward by patch.
+			name:    "bump patch version -- patch conflict rolls forward by patch",
+			release: "v0.13.0",
+			git: git.MockInterface{
+				MockTags: []string{
+					"v0.13.1",
+				},
+			},
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{patchChange},
+				},
+			},
+			want: "v0.13.2",
+		},
+		{
+			name:    "no conflict returns the ideal version",
+			release: "v0.12.0",
+			git: git.MockInterface{
+				MockTags: []string{
+					"v0.12.0",
+				},
+			},
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{minorChange},
+				},
+			},
+			want: "v0.13.0",
+		},
+		{
+			// breaking changes on a v0.x project with EnforceV0 are minor bumps, so a
+			// conflict rolls forward by minor.
+			name:      "bump major version -- enforce v0 conflict rolls forward by minor",
+			release:   "v0.12.0",
+			enforceV0: true,
+			git: git.MockInterface{
+				MockTags: []string{
+					"v0.13.0",
+				},
+			},
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{majorChange},
+				},
+			},
+			want: "v0.14.0",
+		},
+		{
+			// when there are no existing tags the ideal version is returned unchanged.
+			name:    "no tags returns the ideal version",
+			release: "v0.12.0",
+			git:     git.MockInterface{},
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{minorChange},
+				},
+			},
+			want: "v0.13.0",
+		},
+		{
+			// multiple consecutive patch conflicts roll forward by patch.
+			name:    "bump patch version -- multiple patch conflicts roll forward by patch",
+			release: "v0.13.0",
+			git: git.MockInterface{
+				MockTags: []string{
+					"v0.13.1",
+					"v0.13.2",
+				},
+			},
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{patchChange},
+				},
+			},
+			want: "v0.13.3",
+		},
+		{
+			// a version without a "v" prefix keeps its prefix-less form when rolling forward.
+			name:    "no prefix conflict rolls forward without prefix",
+			release: "0.12.0",
+			git: git.MockInterface{
+				MockTags: []string{
+					"0.13.0",
+				},
+			},
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{minorChange},
+				},
+			},
+			want: "0.14.0",
+		},
+		{
+			// no changes with NoChangesBumpsPatch yields a patch bump, so a conflict rolls
+			// forward by patch (the default bump kind for an unknown significance).
+			name:                "no changes bump patch conflict rolls forward by patch",
+			release:             "v0.13.0",
+			bumpPatchOnNoChange: true,
+			git: git.MockInterface{
+				MockTags: []string{
+					"v0.13.1",
+				},
+			},
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{},
+				},
+			},
+			want: "v0.13.2",
+		},
+		{
+			// an error from the underlying ideal-version computation is propagated.
+			name:    "error on bad version is propagated",
+			release: "a10",
+			git:     git.MockInterface{},
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{patchChange},
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			// no changes without NoChangesBumpsPatch errors out at the ideal-version step.
+			name:    "no changes without bump patch errors",
+			release: "v0.13.0",
+			git:     git.MockInterface{},
+			changes: []change.Change{
+				{
+					ChangeTypes: []change.Type{},
+				},
+			},
+			wantErr: require.Error,
 		},
 	}
 	for _, tt := range tests {
@@ -232,6 +419,9 @@ func TestFindNextUniqueVersion(t *testing.T) {
 
 			got, err := s.NextUniqueVersion(tt.release, tt.changes)
 			tt.wantErr(t, err)
+			if err != nil {
+				return
+			}
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
In the case when speculating on a new version, if that version already is represented by a tag, do not attempt to use that tag, move to the next semantically correct tag.